### PR TITLE
[Fix] heroku環境に合わせるためbundle lockコマンドによりGemfile.lock修正 #17

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -110,6 +110,8 @@ GEM
     nio4r (2.5.8)
     nokogiri (1.13.9-x86_64-darwin)
       racc (~> 1.4)
+    nokogiri (1.13.9-x86_64-linux)
+      racc (~> 1.4)
     pg (1.4.5)
     puma (5.6.5)
       nio4r (~> 2.0)
@@ -175,6 +177,7 @@ GEM
 
 PLATFORMS
   x86_64-darwin-22
+  x86_64-linux
 
 DEPENDENCIES
   bootsnap


### PR DESCRIPTION
## Heroku環境構築手順
```
heroku create [アプリ名]
```
```
git push heroku main
```
上のコマンド実行時に`Failed to install gems via Bundler.`エラーのため、ブランチを`heroku_deploy`に切ったのち、指示通りに以下のコマンドを実行した
```
bundle lock --add-platform x86_64-linux
```
Gemfile.lockが更新される。その後、ブランチ内でcommitしHerokuにpush
```
git push heroku heroku_deploy:main
```
![デプロイ完了](https://user-images.githubusercontent.com/26403599/203323916-6555e6af-7017-4306-a738-9e8bb4c15a33.jpg)

