### PR TITLE
[config#32]Railsジェネレーターの設定

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -33,5 +33,12 @@ module TrainingAndMeals
 
     # Don't generate system test files.
     config.generators.system_tests = nil
+
+    config.generators do |g|
+      g.skip_routes true
+      g.assets false
+      g.helper false
+      g.test_framework false
+    end
   end
 end


### PR DESCRIPTION
## 概要
- Railsジェネレーターの設定を変更し不要ファイル等ができないようにする

## 受け入れ条件
以下の項目が自動生成されないこと
- [x] ルーティング
- [x] assetsファイル
- [x] helperファイル
- [x] testファイル

Lintチェック後、修正済みであること
- [x] 確認しました