### PR TITLE
[login_logout_flash_msg#22]ログイン、ログアウト時のフラッシュメッセージの実装

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,2 +1,3 @@
 class ApplicationController < ActionController::Base
+  add_flash_types :success, :info, :warning, :danger
 end

--- a/app/controllers/user_sessions_controller.rb
+++ b/app/controllers/user_sessions_controller.rb
@@ -4,14 +4,15 @@ class UserSessionsController < ApplicationController
   def create
     @user = login(params[:email], params[:password])
     if @user
-      redirect_back_or_to root_path, status: :unprocessable_entity
+      redirect_back_or_to root_path, success: 'ログインしました'
     else
-      render :new
+      flash.now[:danger] = 'emailかパスワードが間違っています'
+      render :new, status: :unprocessable_entity
     end
   end
 
   def destroy
     logout
-    redirect_to root_path, status: :see_other
+    redirect_to root_path, status: :see_other, success: 'ログアウトしました'
   end
 end

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -17,6 +17,7 @@
     <% else %>
       <%= render 'shared/before_login_header' %>
     <% end %>
+    <%= render 'shared/flash_message' %>
     <%= yield %>
     <%= render 'shared/footer' %>
   </body>

--- a/app/views/shared/_flash_message.html.erb
+++ b/app/views/shared/_flash_message.html.erb
@@ -1,0 +1,7 @@
+<% flash.each do |message_type, message| %>
+  <div class="alert alert-<%= message_type %>">
+    <div>
+      <%= message %>
+    </div>
+  </div>
+<% end %>


### PR DESCRIPTION
## 概要
- ログイン、ログアウト時のフラッシュメッセージを追加しました。

## 確認方法
- 登録ユーザーからログイン、ログアウトを実行した時にフラッシュメッセージが表示されること
- 登録されていないemailもしくはパスワードの場合はエラーのフラッシュメッセージが表示されること

## 影響範囲
- フラッシュメッセージのパーシャルを追加し、`application.html.erb`にrenderで読み込むようにしているため、フラッシュメッセージを利用するリソース全体に影響します。

## チェックリスト
- [ ] ブラウザ上で動作を確認した

## コメント
- フラッシュメッセージ含めたログイン、ログアウト処理のテスト未実装のため、今後追加します。TDDに慣れるようにしていきたいと思います。