### PR TITLE
[Profile#23] プロフィール登録機能（カラムの追加、コントローラー、editビューの作成、システムテストの追加）

### DIFF
--- a/app/controllers/profiles_controller.rb
+++ b/app/controllers/profiles_controller.rb
@@ -1,17 +1,18 @@
 class ProfilesController < ApplicationController
   before_action :set_user, only: %i[edit update]
 
+  def show; end
   def edit; end
 
   def update
     if @user.update(user_params)
       set_coefficient
-      if @user.male?
-        @user.maintenance_calorie = (13.397 * @user.body_weight + 4.799 * @user.height - 5.677 * @user.age + 88.362) * @coefficient
-      else
-        @user.maintenance_calorie = (9.247 * @user.body_weight + 3.098 * @user.height - 4.33 * @user.age + 447.593) * @coefficient
-      end
-      @user.target_calorie = ( @user.maintenance_calorie + user_params[:adjustment_calorie].to_i + 500 )
+      @user.maintenance_calorie = if @user.male?
+                                    ((13.397 * @user.body_weight) + (4.799 * @user.height) - (5.677 * @user.age) + 88.362) * @coefficient
+                                  else
+                                    ((9.247 * @user.body_weight) + (3.098 * @user.height) - (4.33 * @user.age) + 447.593) * @coefficient
+                                  end
+      @user.target_calorie = (@user.maintenance_calorie + user_params[:adjustment_calorie].to_i + 500)
       @user.save!
       redirect_to edit_profile_path, success: '情報を更新しました'
     else
@@ -20,25 +21,23 @@ class ProfilesController < ApplicationController
     end
   end
 
-  def show; end
-
   private
 
   def set_coefficient
-    case @user.active_level
-    when 'level1'
-      @coefficient = 1.2
-    when 'level2'
-      @coefficient = 1.375
-    when 'level3'
-      @coefficient = 1.55
-    when 'level4'
-      @coefficient = 1.725
-    when 'level5'
-      @coefficient = 1.9
-    else
-      @coefficient = 1
-    end
+    @coefficient = case @user.active_level
+                   when 'level1'
+                     1.2
+                   when 'level2'
+                     1.375
+                   when 'level3'
+                     1.55
+                   when 'level4'
+                     1.725
+                   when 'level5'
+                     1.9
+                   else
+                     1
+                   end
   end
 
   def set_user
@@ -46,6 +45,8 @@ class ProfilesController < ApplicationController
   end
 
   def user_params
-    params.require(:user).permit(:email, :name, :introduction, :height, :body_weight, :age, :sex, :active_level, :target_weight, :target_date, :adjustment_calorie, :twitter_link, :facebook_link, :instagram_link)
+    params.require(:user).permit(:email, :name, :introduction, :height, :body_weight,
+                                 :age, :sex, :active_level, :target_weight,
+                                 :target_date, :adjustment_calorie, :twitter_link, :facebook_link, :instagram_link)
   end
 end

--- a/app/controllers/profiles_controller.rb
+++ b/app/controllers/profiles_controller.rb
@@ -5,7 +5,15 @@ class ProfilesController < ApplicationController
 
   def update
     if @user.update(user_params)
-      redirect_to profile_path, success: '情報を更新しました'
+      set_coefficient
+      if @user.male?
+        @user.maintenance_calorie = (13.397 * @user.body_weight + 4.799 * @user.height - 5.677 * @user.age + 88.362) * @coefficient
+      else
+        @user.maintenance_calorie = (9.247 * @user.body_weight + 3.098 * @user.height - 4.33 * @user.age + 447.593) * @coefficient
+      end
+      @user.target_calorie = ( @user.maintenance_calorie + user_params[:adjustment_calorie].to_i + 500 )
+      @user.save!
+      redirect_to edit_profile_path, success: '情報を更新しました'
     else
       flash.now['danger'] = '更新できませんでした'
       render :edit
@@ -16,11 +24,28 @@ class ProfilesController < ApplicationController
 
   private
 
+  def set_coefficient
+    case @user.active_level
+    when 'level1'
+      @coefficient = 1.2
+    when 'level2'
+      @coefficient = 1.375
+    when 'level3'
+      @coefficient = 1.55
+    when 'level4'
+      @coefficient = 1.725
+    when 'level5'
+      @coefficient = 1.9
+    else
+      @coefficient = 1
+    end
+  end
+
   def set_user
     @user = User.find(current_user.id)
   end
 
   def user_params
-    params.require(:user).permit(:email, :name)
+    params.require(:user).permit(:email, :name, :introduction, :height, :body_weight, :age, :sex, :active_level, :target_weight, :target_date, :adjustment_calorie, :twitter_link, :facebook_link, :instagram_link)
   end
 end

--- a/app/controllers/profiles_controller.rb
+++ b/app/controllers/profiles_controller.rb
@@ -16,7 +16,7 @@ class ProfilesController < ApplicationController
       redirect_to edit_profile_path, success: '情報を更新しました'
     else
       flash.now['danger'] = '更新できませんでした'
-      render :edit
+      render :edit, status: :unprocessable_entity
     end
   end
 

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -6,4 +6,7 @@ class User < ApplicationRecord
   validates :password, length: { minimum: 3 }, if: -> { new_record? || changes[:crypted_password] }
   validates :password, confirmation: true, if: -> { new_record? || changes[:crypted_password] }
   validates :password_confirmation, presence: true, if: -> { new_record? || changes[:crypted_password] }
+
+  enum sex: { male: 0, female: 1 }
+  enum active_level: { level1: 1, level2: 2, level3: 3, level4: 4, level5: 5 }
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -8,11 +8,9 @@ class User < ApplicationRecord
   validates :password_confirmation, presence: true, if: -> { new_record? || changes[:crypted_password] }
   validates :height, presence: true, on: :update
   validates :body_weight, presence: true, on: :update
-  validates :body_weight, presence: true, on: :update
   validates :age, presence: true, on: :update
   validates :sex, presence: true, on: :update
   validates :active_level, presence: true, on: :update
-
 
   enum sex: { male: 0, female: 1 }
   enum active_level: { level1: 1, level2: 2, level3: 3, level4: 4, level5: 5 }

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -6,6 +6,13 @@ class User < ApplicationRecord
   validates :password, length: { minimum: 3 }, if: -> { new_record? || changes[:crypted_password] }
   validates :password, confirmation: true, if: -> { new_record? || changes[:crypted_password] }
   validates :password_confirmation, presence: true, if: -> { new_record? || changes[:crypted_password] }
+  validates :height, presence: true, on: :update
+  validates :body_weight, presence: true, on: :update
+  validates :body_weight, presence: true, on: :update
+  validates :age, presence: true, on: :update
+  validates :sex, presence: true, on: :update
+  validates :active_level, presence: true, on: :update
+
 
   enum sex: { male: 0, female: 1 }
   enum active_level: { level1: 1, level2: 2, level3: 3, level4: 4, level5: 5 }

--- a/app/views/profiles/edit.html.erb
+++ b/app/views/profiles/edit.html.erb
@@ -1,92 +1,74 @@
-<div class="container mx-auto">
-  <div class="drawer drawer-mobile">
-    <input id="my-drawer-2" type="checkbox" class="drawer-toggle" />
-    <div class="drawer-side">
-      <label for="my-drawer-2" class="drawer-overlay"></label> 
-      <ul class="menu bg-base-100 w-56 rounded-box">
-        <li><a>Sidebar Item 1</a></li>
-        <li><a>Sidebar Item 2</a></li>
-      </ul>
+<div class="container mx-auto px-8 w-full">
+  <%= form_with model: @user, url: profile_path, local: true do |f| %>
+  <%= render 'shared/error_messages', object: f.object %>
+    <h2 class="mt-5">名前</h2>
+    <p><%= @user.name %></p>
+    <h2>メールアドレス</h2>
+    <p><%= current_user.email %></p>
+    <div class="form-control">
+      <%= f.label :introduction %>
+      <%= f.text_area :introduction, class: "input input-bordered" %>
     </div>
-    <div class="drawer-content flex justify-between">
-      <div class="w-full grid lg:grid-cols-3">
-        <label for="my-drawer-2" class="btn btn-primary drawer-button mt-5 lg:hidden">Open drawer</label>
-        <%= form_with model: current_user, url: profile_path, local: true do |f| %>
-        <div>
-          <h2>名前</h2>
-          <p><%= current_user.name %></p>
-          <h2>メールアドレス</h2>
-          <p><%= current_user.email %></p>
-          <div class="form-control">
-            <%= f.label :introduction %>
-            <%= f.text_area :introduction, class: "input input-bordered" %>
-          </div>
-          <div class="form-control">
-            <%= f.label :twitter_link%>
-            <%= f.url_field :twitter_link, class: "input input-bordered" %>
-          </div>
-          <div class="form-control">
-            <%= f.label :facebook_link%>
-            <%= f.url_field :facebook_link, class: "input input-bordered" %>
-          </div>
-          <div class="form-control">
-            <%= f.label :instagram_link%>
-            <%= f.url_field :instagram_link, class: "input input-bordered" %>
-          </div>
-        </div>
-        <div>
-          <div class="form-control">
-            <%= f.label :height %>
-            <%= f.number_field :height, class: "input input-bordered" %>
-          </div>
-          <div class="form-control">
-            <%= f.label :body_weight %>
-            <%= f.number_field :body_weight, class: "input input-bordered" %>
-          </div>
-          <div class="form-control">
-            <%= f.label :age %>
-            <%= f.number_field :age, class: "form-control input input-bordered" %>
-          </div>
-          <div class="form-control">
-            <%= f.label :sex %>
-            <%= f.select :sex, User.sexes.keys.map {|k| [k, k]}, class: "form-control input input-bordered" %>
-          </div>
-          <div class="form-control">
-            <%= f.label :active_level%>
-            <%= f.select :active_level, User.active_levels.keys.map {|k| [k, k]}, class: "form-control input input-bordered" %>
-          </div>
-          <div class="form-control">
-            <%= f.label :target_weight%>
-            <%= f.number_field :target_weight, class: "form-control input input-bordered" %>
-          </div>
-          <div class="form-control">
-            <%= f.label :target_date%>
-            <%= f.date_field :target_date, class: "form-control input input-bordered" %>
-          </div>
-          <div class="form-control mt-6">
-            <%= f.submit '計算する', class: "btn btn-primary"%>
-          </div>
-        </div>
-        <% end %>
-        <div>
-          <div>
-            <p class="font-bold">あなたの目標摂取カロリーは１日あたり </p>
-            <p class="font-bold text-3xl text-center"><%= @current_user.target_calorie%> <p>
-            <p class="font-bold text-right">kcalです</p>
-          </div>
-          <%= form_with model: current_user, url: profile_path, local: true do |f| %>
-          <div class="form-control mt-6">
-            <p>カロリー調整を設定できます</p>
-            <%= f.label :adjustment_calorie%>
-            <%= f.number_field :adjustment_calorie, class: "form-control input input-bordered" %>
-          </div>
-          <div class="form-control mt-6">
-            <%= f.submit '追加する', class: "btn btn-primary"%>
-          </div>
-          <% end %>
-        </div>
-      </div>
+    <div class="form-control">
+      <%= f.label :twitter_link%>
+      <%= f.url_field :twitter_link, class: "input input-bordered" %>
     </div>
+    <div class="form-control">
+      <%= f.label :facebook_link%>
+      <%= f.url_field :facebook_link, class: "input input-bordered" %>
+    </div>
+    <div class="form-control">
+      <%= f.label :instagram_link%>
+      <%= f.url_field :instagram_link, class: "input input-bordered" %>
+    </div>
+    <div class="form-control">
+      <%= f.label :height %>
+      <%= f.number_field :height, class: "input input-bordered" %>
+    </div>
+    <div class="form-control">
+      <%= f.label :body_weight %>
+      <%= f.number_field :body_weight, class: "input input-bordered" %>
+    </div>
+    <div class="form-control">
+      <%= f.label :age %>
+      <%= f.number_field :age, class: "form-control input input-bordered" %>
+    </div>
+    <div class="form-control">
+      <%= f.label :sex %>
+      <%= f.select :sex, User.sexes.keys.map {|k| [k, k]}, class: "form-control input input-bordered" %>
+    </div>
+    <div class="form-control">
+      <%= f.label :active_level%>
+      <%= f.select :active_level, User.active_levels.keys.map {|k| [k, k]}, class: "form-control input input-bordered" %>
+    </div>
+    <div class="form-control">
+      <%= f.label :target_weight%>
+      <%= f.number_field :target_weight, class: "form-control input input-bordered" %>
+    </div>
+    <div class="form-control">
+      <%= f.label :target_date%>
+      <%= f.date_field :target_date, class: "form-control input input-bordered" %>
+    </div>
+    <div class="form-control mt-6">
+      <%= f.submit '計算する', class: "btn btn-primary"%>
+    </div>
+  <% end %>
+  <div>
+    <div>
+      <p class="font-bold">あなたの目標摂取カロリーは１日あたり </p>
+      <p class="font-bold text-3xl text-center"><%= @current_user.target_calorie%> <p>
+      <p class="font-bold text-right">kcalです</p>
+    </div>
+    <%= form_with model: current_user, url: profile_path, local: true do |f| %>
+    <div class="form-control mt-6">
+      <p>カロリーを調整できます</p>
+      <%= f.label :adjustment_calorie%>
+      <%= f.number_field :adjustment_calorie, class: "form-control input input-bordered" %>
+    </div>
+    <div class="form-control mt-6">
+      <%= f.submit '調整する', class: "btn btn-primary"%>
+    </div>
+    <% end %>
   </div>
 </div>
 

--- a/app/views/profiles/edit.html.erb
+++ b/app/views/profiles/edit.html.erb
@@ -1,0 +1,92 @@
+<div class="container mx-auto">
+  <div class="drawer drawer-mobile">
+    <input id="my-drawer-2" type="checkbox" class="drawer-toggle" />
+    <div class="drawer-side">
+      <label for="my-drawer-2" class="drawer-overlay"></label> 
+      <ul class="menu bg-base-100 w-56 rounded-box">
+        <li><a>Sidebar Item 1</a></li>
+        <li><a>Sidebar Item 2</a></li>
+      </ul>
+    </div>
+    <div class="drawer-content flex justify-between">
+      <div class="w-full grid lg:grid-cols-3">
+        <label for="my-drawer-2" class="btn btn-primary drawer-button mt-5 lg:hidden">Open drawer</label>
+        <%= form_with model: current_user, url: profile_path, local: true do |f| %>
+        <div>
+          <h2>名前</h2>
+          <p><%= current_user.name %></p>
+          <h2>メールアドレス</h2>
+          <p><%= current_user.email %></p>
+          <div class="form-control">
+            <%= f.label :introduction %>
+            <%= f.text_area :introduction, class: "input input-bordered" %>
+          </div>
+          <div class="form-control">
+            <%= f.label :twitter_link%>
+            <%= f.url_field :twitter_link, class: "input input-bordered" %>
+          </div>
+          <div class="form-control">
+            <%= f.label :facebook_link%>
+            <%= f.url_field :facebook_link, class: "input input-bordered" %>
+          </div>
+          <div class="form-control">
+            <%= f.label :instagram_link%>
+            <%= f.url_field :instagram_link, class: "input input-bordered" %>
+          </div>
+        </div>
+        <div>
+          <div class="form-control">
+            <%= f.label :height %>
+            <%= f.number_field :height, class: "input input-bordered" %>
+          </div>
+          <div class="form-control">
+            <%= f.label :body_weight %>
+            <%= f.number_field :body_weight, class: "input input-bordered" %>
+          </div>
+          <div class="form-control">
+            <%= f.label :age %>
+            <%= f.number_field :age, class: "form-control input input-bordered" %>
+          </div>
+          <div class="form-control">
+            <%= f.label :sex %>
+            <%= f.select :sex, User.sexes.keys.map {|k| [k, k]}, class: "form-control input input-bordered" %>
+          </div>
+          <div class="form-control">
+            <%= f.label :active_level%>
+            <%= f.select :active_level, User.active_levels.keys.map {|k| [k, k]}, class: "form-control input input-bordered" %>
+          </div>
+          <div class="form-control">
+            <%= f.label :target_weight%>
+            <%= f.number_field :target_weight, class: "form-control input input-bordered" %>
+          </div>
+          <div class="form-control">
+            <%= f.label :target_date%>
+            <%= f.date_field :target_date, class: "form-control input input-bordered" %>
+          </div>
+          <div class="form-control mt-6">
+            <%= f.submit '計算する', class: "btn btn-primary"%>
+          </div>
+        </div>
+        <% end %>
+        <div>
+          <div>
+            <p class="font-bold">あなたの目標摂取カロリーは１日あたり </p>
+            <p class="font-bold text-3xl text-center"><%= @current_user.target_calorie%> <p>
+            <p class="font-bold text-right">kcalです</p>
+          </div>
+          <%= form_with model: current_user, url: profile_path, local: true do |f| %>
+          <div class="form-control mt-6">
+            <p>カロリー調整を設定できます</p>
+            <%= f.label :adjustment_calorie%>
+            <%= f.number_field :adjustment_calorie, class: "form-control input input-bordered" %>
+          </div>
+          <div class="form-control mt-6">
+            <%= f.submit '追加する', class: "btn btn-primary"%>
+          </div>
+          <% end %>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+

--- a/app/views/shared/_before_login_header.html.erb
+++ b/app/views/shared/_before_login_header.html.erb
@@ -1,5 +1,5 @@
 <header>
-  <div class="navbar bg-base-100 bg-primary">
+  <div class="navbar bg-primary">
     <div class="flex-1">
       <a class="btn btn-ghost normal-case text-xl">トレミル</a>
     </div>

--- a/app/views/shared/_error_messages.html.erb
+++ b/app/views/shared/_error_messages.html.erb
@@ -1,0 +1,9 @@
+<% if object.errors.any? %>
+  <div class="alert alert-warning shadow-lg mt-5">
+    <ul>
+      <% object.errors.full_messages.each do |msg| %>
+        <li><%= msg %></li>
+      <% end %>
+    </ul>
+  </div>
+<% end %>

--- a/app/views/shared/_header.html.erb
+++ b/app/views/shared/_header.html.erb
@@ -1,5 +1,5 @@
 <header>
-  <div class="navbar bg-base-100 bg-primary">
+  <div class="navbar bg-primary">
     <div class="flex-1">
       <a class="btn btn-ghost normal-case text-xl">トレミル</a>
     </div>

--- a/db/migrate/20221205123321_add_profiles_to_users.rb
+++ b/db/migrate/20221205123321_add_profiles_to_users.rb
@@ -1,0 +1,18 @@
+class AddProfilesToUsers < ActiveRecord::Migration[7.0]
+  def change
+    add_column :users, :introduction,        :text
+    add_column :users, :height,              :float
+    add_column :users, :body_weight,         :float
+    add_column :users, :age,                 :integer
+    add_column :users, :sex,                 :integer
+    add_column :users, :active_level,        :integer
+    add_column :users, :target_weight,       :float
+    add_column :users, :target_date,         :datetime
+    add_column :users, :maintenance_calorie, :integer
+    add_column :users, :adjustment_calorie,  :integer
+    add_column :users, :target_calorie,      :integer
+    add_column :users, :twitter_link,        :string
+    add_column :users, :facebook_link,       :string
+    add_column :users, :instagram_link,      :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2022_11_26_011411) do
+ActiveRecord::Schema[7.0].define(version: 2022_12_05_123321) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -21,6 +21,20 @@ ActiveRecord::Schema[7.0].define(version: 2022_11_26_011411) do
     t.string "salt"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.text "introduction"
+    t.float "height"
+    t.float "body_weight"
+    t.integer "age"
+    t.integer "sex"
+    t.integer "active_level"
+    t.float "target_weight"
+    t.datetime "target_date"
+    t.integer "maintenance_calorie"
+    t.integer "adjustment_calorie"
+    t.integer "target_calorie"
+    t.string "twitter_link"
+    t.string "facebook_link"
+    t.string "instagram_link"
     t.index ["email"], name: "index_users_on_email", unique: true
   end
 

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -4,5 +4,10 @@ FactoryBot.define do
     sequence(:email) { |n| "user_#{n}@example.com" }
     password { 'password' }
     password_confirmation { 'password' }
+    height { 163.5 }
+    body_weight { 85 }
+    age { 32 }
+    sex { 'male' }
+    active_level { 'level1' }
   end
 end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -37,5 +37,40 @@ RSpec.describe User do
       another_user.valid?
       expect(another_user.errors[:email]).to include('has already been taken')
     end
+
+    it '身長が未入力では更新できないこと' do
+      user = create(:user)
+      user.height = ''
+      user.valid?
+      expect(user.errors[:height]).to include("can't be blank")
+    end
+
+    it '体重が未入力では更新できないこと' do
+      user = create(:user)
+      user.body_weight = ''
+      user.valid?
+      expect(user.errors[:body_weight]).to include("can't be blank")
+    end
+
+    it '年齢が未入力では更新できないこと' do
+      user = create(:user)
+      user.age = ''
+      user.valid?
+      expect(user.errors[:age]).to include("can't be blank")
+    end
+
+    it '性別が未入力では更新できないこと' do
+      user = create(:user)
+      user.sex = ''
+      user.valid?
+      expect(user.errors[:sex]).to include("can't be blank")
+    end
+
+    it '活動レベルが未入力では更新できないこと' do
+      user = create(:user)
+      user.active_level = ''
+      user.valid?
+      expect(user.errors[:active_level]).to include("can't be blank")
+    end
   end
 end

--- a/spec/system/profiles_spec.rb
+++ b/spec/system/profiles_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-RSpec.describe "Profiles", type: :system do
+RSpec.describe 'Profiles' do
   let(:user) { create(:user) }
 
   it 'プロフィール登録するすると、メンテナンスカロリーと目標カロリーが登録され、表示されること' do

--- a/spec/system/profiles_spec.rb
+++ b/spec/system/profiles_spec.rb
@@ -1,0 +1,18 @@
+require 'rails_helper'
+
+RSpec.describe "Profiles", type: :system do
+  let(:user) { create(:user) }
+
+  it 'プロフィール登録するすると、メンテナンスカロリーと目標カロリーが登録され、表示されること' do
+    login_as(user)
+    visit edit_profile_path
+    fill_in 'Height', with: user.height
+    fill_in 'Body weight', with: user.body_weight
+    fill_in 'Age', with: user.age
+    select 'male', from: 'Sex'
+    select 'level1', from: 'Active level'
+    click_button '計算する'
+    expect(page).to have_content 'あなたの目標摂取カロリーは１日あたり'
+    expect(page).to have_current_path edit_profile_path, ignore_query: true
+  end
+end

--- a/spec/system/user_sessions_spec.rb
+++ b/spec/system/user_sessions_spec.rb
@@ -11,7 +11,7 @@ RSpec.describe 'UserSessions' do
         fill_in 'Password', with: 'password'
         click_button 'ログイン'
         expect(page).to have_content 'ログインしました'
-        expect(page).to have_current_path root_path, ignore_query: true
+        expect(page).to have_current_path profile_path, ignore_query: true
       end
     end
 


### PR DESCRIPTION
## 概要
プロフィール登録機能を追加しました
- usersテーブルにカラムを追加
- 性別（sex）と活動レベル（active_level）についてはenumで実装
- コントローラーへedit, updateアクションの追加
- updateアクションに目標摂取カロリー計算ロジック追加（暫定）
- usersモデルにバリデーションの追加
- editビューの作成（暫定）
- プロフィール登録機能のシステムテストの追加（暫定）

## 確認方法

1. カラム を追加したので `bin/raild db:migrate` を実行してください
2. /profile/editにアクセスしてユーザー登録できることを確認してください
3. 目標摂取カロリーが自動計算されることを確認してください

## 影響範囲
- usersモデル

## チェックリスト

- [x] システムテストをパスした
- [x] Lintチェックの指摘を修正した

## コメント
- updateアクション内のロジックはリファクタリングしたい（メンテナンスカロリーを計算する部分）
- i18n対応も行っておきたい
- ビューは最後に修正予定
