### PR TITLE
[user_registration#21] createアクションの修正、 ユーザー登録時のエラー表示追加 #21

### DIFF
--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -8,9 +8,10 @@ class UsersController < ApplicationController
   def create
     @user = User.new(user_params)
     if @user.save
-      redirect_to login_path
+      redirect_to login_path, success: '登録しました'
     else
-      render :new
+      flash.now['danger'] = '登録できませんでした'
+      render :new, status: :unprocessable_entity
     end
   end
 

--- a/app/views/users/new.html.erb
+++ b/app/views/users/new.html.erb
@@ -7,6 +7,7 @@
     <div class="card flex-shrink-0 w-full max-w-sm shadow-2xl bg-base-100">
       <div class="card-body">
         <%= form_with model: @user, local: true do |f| %>
+        <%= render 'shared/error_messages', object: f.object %>
           <div class="form-control">
             <%= f.label :name %>
             <%= f.text_field :name, class: "input input-bordered" %>

--- a/spec/system/users_spec.rb
+++ b/spec/system/users_spec.rb
@@ -16,6 +16,7 @@ RSpec.describe 'Users' do
         fill_in 'Password', with: 'password'
         fill_in 'Password confirmation', with: 'password'
         click_button '登録する'
+        expect(page).to have_content '登録しました'
         expect(page).to have_current_path login_path, ignore_query: true
       end
     end
@@ -28,6 +29,8 @@ RSpec.describe 'Users' do
         fill_in 'Password', with: 'password'
         fill_in 'Password confirmation', with: 'password'
         click_button '登録する'
+        expect(page).to have_content '登録できませんでした'
+        expect(page).to have_content "Email can't be blank"
         expect(page).to have_current_path users_path, ignore_query: true
       end
     end
@@ -41,6 +44,23 @@ RSpec.describe 'Users' do
         fill_in 'Password', with: 'password'
         fill_in 'Password confirmation', with: 'password'
         click_button '登録する'
+        expect(page).to have_content '登録できませんでした'
+        expect(page).to have_content 'Email has already been taken'
+        expect(page).to have_current_path users_path, ignore_query: true
+      end
+    end
+
+    context 'パスワードが不一致' do
+      it 'ユーザーの新規作成が失敗する' do
+        existed_user = create(:user)
+        visit new_user_path
+        fill_in 'Name', with: 'Example'
+        fill_in 'Email', with: existed_user.email
+        fill_in 'Password', with: 'password'
+        fill_in 'Password confirmation', with: 'foobar'
+        click_button '登録する'
+        expect(page).to have_content '登録できませんでした'
+        expect(page).to have_content "Password confirmation doesn't match Password"
         expect(page).to have_current_path users_path, ignore_query: true
       end
     end


### PR DESCRIPTION
## 概要
- ユーザー登録時のフラッシュメッセージの追加
- ユーザー登録失敗時のコードの修正
- ビューにバリデーションエラーメッセージパーシャルのレンダリング追加

## 確認方法
- ユーザー登録成功or失敗時フラッシュメッセージが表示されることを確認してください

## 影響範囲
- ユーザー登録機能のみ

## チェックリスト
- [x] Lint のチェックをパスした
- [x] テストをパスした

## コメント
エラーメッセージのテストはi18nの日本語化を行った後に修正します。