### PR TITLE
[i18n#49] テストをi18n日本語化対応に修正

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -51,6 +51,8 @@ gem 'bootsnap', require: false
 gem 'cssbundling-rails'
 gem 'jsbundling-rails'
 gem 'sorcery'
+gem 'rails-i18n', '~> 7.0.0' 
+gem 'enum_help'
 
 group :development, :test do
   # See https://guides.rubyonrails.org/debugging_rails_applications.html#debugging-with-the-debug-gem

--- a/Gemfile
+++ b/Gemfile
@@ -49,10 +49,10 @@ gem 'bootsnap', require: false
 # gem "image_processing", "~> 1.2"
 
 gem 'cssbundling-rails'
-gem 'jsbundling-rails'
-gem 'sorcery'
-gem 'rails-i18n', '~> 7.0.0' 
 gem 'enum_help'
+gem 'jsbundling-rails'
+gem 'rails-i18n', '~> 7.0.0'
+gem 'sorcery'
 
 group :development, :test do
   # See https://guides.rubyonrails.org/debugging_rails_applications.html#debugging-with-the-debug-gem

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -92,6 +92,8 @@ GEM
       irb (>= 1.3.6)
       reline (>= 0.3.1)
     diff-lcs (1.5.0)
+    enum_help (0.0.19)
+      activesupport (>= 3.0.0)
     erubi (1.11.0)
     factory_bot (6.2.1)
       activesupport (>= 5.0.0)
@@ -187,6 +189,9 @@ GEM
       nokogiri (>= 1.6)
     rails-html-sanitizer (1.4.3)
       loofah (~> 2.3)
+    rails-i18n (7.0.6)
+      i18n (>= 0.7, < 2)
+      railties (>= 6.0.0, < 8)
     railties (7.0.4)
       actionpack (= 7.0.4)
       activesupport (= 7.0.4)
@@ -299,6 +304,7 @@ DEPENDENCIES
   capybara
   cssbundling-rails
   debug
+  enum_help
   factory_bot_rails
   faker
   importmap-rails
@@ -307,6 +313,7 @@ DEPENDENCIES
   pg (~> 1.1)
   puma (~> 5.0)
   rails (~> 7.0.4)
+  rails-i18n (~> 7.0.0)
   redis (~> 4.0)
   rspec-rails
   rubocop

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -3,7 +3,7 @@ class ApplicationController < ActionController::Base
   before_action :require_login
 
   def not_authenticated
-    flash[:warning] = 'ログインしてください'
+    flash[:warning] = t('defaults.message.require_login')
     redirect_to login_path
   end
 end

--- a/app/controllers/user_sessions_controller.rb
+++ b/app/controllers/user_sessions_controller.rb
@@ -6,15 +6,15 @@ class UserSessionsController < ApplicationController
   def create
     @user = login(params[:email], params[:password])
     if @user
-      redirect_back_or_to profile_path, success: 'ログインしました'
+      redirect_back_or_to profile_path, success: t('.success')
     else
-      flash.now[:danger] = 'emailかパスワードが間違っています'
+      flash.now[:danger] = t('.fail')
       render :new, status: :unprocessable_entity
     end
   end
 
   def destroy
     logout
-    redirect_to root_path, status: :see_other, success: 'ログアウトしました'
+    redirect_to root_path, status: :see_other, success: t('.success')
   end
 end

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -8,9 +8,9 @@ class UsersController < ApplicationController
   def create
     @user = User.new(user_params)
     if @user.save
-      redirect_to login_path, success: '登録しました'
+      redirect_to login_path, success: t('.success')
     else
-      flash.now['danger'] = '登録できませんでした'
+      flash.now['danger'] = t('.fail')
       render :new, status: :unprocessable_entity
     end
   end

--- a/app/views/profiles/edit.html.erb
+++ b/app/views/profiles/edit.html.erb
@@ -1,4 +1,5 @@
 <div class="container mx-auto px-8 w-full">
+  <h1 class="text-5xl font-bold"><%= t '.title' %></h1>
   <%= form_with model: @user, url: profile_path, local: true do |f| %>
   <%= render 'shared/error_messages', object: f.object %>
     <h2 class="mt-5">名前</h2>
@@ -35,11 +36,11 @@
     </div>
     <div class="form-control">
       <%= f.label :sex %>
-      <%= f.select :sex, User.sexes.keys.map {|k| [k, k]}, class: "form-control input input-bordered" %>
+      <%= f.select :sex, User.sexes_i18n.invert.map{|key, value| [key, value]}, class: "form-control input input-bordered" %>
     </div>
     <div class="form-control">
       <%= f.label :active_level%>
-      <%= f.select :active_level, User.active_levels.keys.map {|k| [k, k]}, class: "form-control input input-bordered" %>
+      <%= f.select :active_level, User.active_levels_i18n.invert.map{|key, value| [key, value]}, class: "form-control input input-bordered" %>
     </div>
     <div class="form-control">
       <%= f.label :target_weight%>

--- a/app/views/shared/_before_login_header.html.erb
+++ b/app/views/shared/_before_login_header.html.erb
@@ -5,9 +5,9 @@
     </div>
     <div class="flex-none">
       <ul class="menu menu-horizontal p-0">
-        <li><%= link_to 'About', "#" %></li>
-        <li><%= link_to 'Singup', new_user_path %></li>
-        <li><%= link_to 'Login', login_path %></li>
+        <li><%= link_to (t 'defaults.about'), "#" %></li>
+        <li><%= link_to (t 'defaults.signup'), new_user_path %></li>
+        <li><%= link_to (t 'defaults.login'), login_path %></li>
       </ul>
     </div>
   </div>

--- a/app/views/shared/_header.html.erb
+++ b/app/views/shared/_header.html.erb
@@ -21,7 +21,7 @@
             </a>
           </li>
           <li><a>Settings</a></li>
-          <li><%= link_to 'ログアウト', logout_path, data: { turbo_method: :delete } %></li>
+          <li><%= link_to (t 'defaults.logout'), logout_path, data: { turbo_method: :delete } %></li>
         </ul>
       </div>
     </div>

--- a/app/views/user_sessions/new.html.erb
+++ b/app/views/user_sessions/new.html.erb
@@ -1,27 +1,27 @@
 <div class="hero min-h-screen bg-base-200">
   <div class="hero-content flex-col lg:flex-row-reverse">
     <div class="text-center lg:text-left">
-      <h1 class="text-5xl font-bold">Login now!</h1>
+      <h1 class="text-5xl font-bold"><%= t '.title' %></h1>
       <p class="py-6">Provident cupiditate voluptatem et in. Quaerat fugiat ut assumenda excepturi exercitationem quasi. In deleniti eaque aut repudiandae et a id nisi.</p>
     </div>
     <div class="card flex-shrink-0 w-full max-w-sm shadow-2xl bg-base-100">
       <div class="card-body">
         <%= form_with url: login_path, local: true do |f| %>
           <div class="form-control">
-            <%= f.label :email %>
+            <%= f.label :email, User.human_attribute_name(:email) %>
             <%= f.text_field :email, class: 'input input-bordered' %>
           </div>
           <div class="form-control">
-            <%= f.label :password %>
+            <%= f.label :password, User.human_attribute_name(:password) %>
             <%= f.password_field :password, class: 'input input-bordered' %>
           </div>
           <div class="form-control mt-6">
-            <%= f.submit 'ログイン', class: 'btn btn-primary' %>
+            <%= f.submit (t 'defaults.login'), class: 'btn btn-primary' %>
           </div>
         <% end %>
         <div class='label-text-alt link link-hove'>
-          <%= link_to '登録ページへ', new_user_path %>
-          <a href="#">パスワードをお忘れの方はこちら</a>
+          <%= link_to (t '.to_register_page'), new_user_path %>
+          <a href="#"><%= t '.password_forget' %></a>
         </div>
       </div>
     </div>

--- a/app/views/users/new.html.erb
+++ b/app/views/users/new.html.erb
@@ -1,7 +1,7 @@
 <div class="hero min-h-screen bg-base-200">
   <div class="hero-content flex-col lg:flex-row">
     <div class="text-center lg:text-left">
-      <h1 class="text-5xl font-bold">ユーザー登録</h1>
+      <h1 class="text-5xl font-bold"><%= t '.title' %></h1>
       <p class="py-6">まっちょまっちょ</p>
     </div>
     <div class="card flex-shrink-0 w-full max-w-sm shadow-2xl bg-base-100">
@@ -25,7 +25,7 @@
             <%= f.password_field :password_confirmation, class: "form-control input input-bordered" %>
           </div>
           <div class="form-control mt-6">
-            <%= f.submit '登録する', class: "btn btn-primary"%>
+            <%= f.submit (t 'defaults.register'), class: "btn btn-primary"%>
           </div>
         <% end %>
       </div>

--- a/config/application.rb
+++ b/config/application.rb
@@ -43,5 +43,8 @@ module TrainingAndMeals
       helper_specs: false,
       routing_specs: false
     end
+
+    config.i18n.default_locale = :ja
+    config.i18n.load_path += Dir[Rails.root.join('config/locales/**/*.{rb,yml}').to_s]
   end
 end

--- a/config/locales/activerecord/ja.yml
+++ b/config/locales/activerecord/ja.yml
@@ -1,0 +1,35 @@
+ja:
+  activerecord:
+    models:
+      user: "ユーザー"
+    attributes:
+      user:
+        name: 名前
+        email: "メールアドレス"
+        password: "パスワード"
+        password_confirmation: "パスワード（確認用）"
+        introduction: "自己紹介"
+        height: "身長"
+        body_weight: "体重"
+        age: "年齢"
+        sex: "生まれた時の性別"
+        active_level: "活動量"
+        target_weight: "目標体重"
+        target_date: "目標達成日"
+        maintenance_calorie: "メンテナンスカロリー"
+        adjustment_calorie: "調整カロリー"
+        target_calorie: "目標摂取カロリー"
+        twitter_link: "Twitterリンク"
+        facebook_link: "Facebookリンク"
+        instagram_link: "Instagramリンク"
+  enums:
+    user:
+      sex:
+        male: "男性"
+        female: "女性"
+      active_level:
+        level1: "レベル1"
+        level2: "レベル2"
+        level3: "レベル3"
+        level4: "レベル4"
+        level5: "レベル5"

--- a/config/locales/views/ja.yml
+++ b/config/locales/views/ja.yml
@@ -5,15 +5,25 @@ ja:
     register: "登録"
     logout: "ログアウト"
     about: "このアプリについて"
+    message:
+      require_login: "ログインしてください"
   users:
     new:
       title: "ユーザー登録"
       to_login_page: "ログインページへ"
+    create:
+      success: "ユーザー登録が完了しました"
+      fail: "ユーザー登録に失敗しました"
   user_sessions:
     new:
       title: "ログイン"
       to_register_page: "登録ページへ"
       password_forget: "パスワードをお忘れの方はこちら"
+    create:
+      success: "ログインしました"
+      fail: "ログインに失敗しました（メールアドレスかパスワードが間違っています）"
+    destroy:
+      success: "ログアウトしました"
   profiles:
     edit:
       title: "プロフィール編集"

--- a/config/locales/views/ja.yml
+++ b/config/locales/views/ja.yml
@@ -1,0 +1,19 @@
+ja:
+  defaults:
+    signup: "新規登録"
+    login: "ログイン"
+    register: "登録"
+    logout: "ログアウト"
+    about: "このアプリについて"
+  users:
+    new:
+      title: "ユーザー登録"
+      to_login_page: "ログインページへ"
+  user_sessions:
+    new:
+      title: "ログイン"
+      to_register_page: "登録ページへ"
+      password_forget: "パスワードをお忘れの方はこちら"
+  profiles:
+    edit:
+      title: "プロフィール編集"

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe User do
     it '名前がなければ無効な状態であること' do
       user = build(:user, name: '')
       user.valid?
-      expect(user.errors[:name]).to include("を入力してください")
+      expect(user.errors[:name]).to include('を入力してください')
     end
 
     it 'メールアドレスがなければ無効な状態であること' do

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -10,67 +10,67 @@ RSpec.describe User do
     it '名前がなければ無効な状態であること' do
       user = build(:user, name: '')
       user.valid?
-      expect(user.errors[:name]).to include("can't be blank")
+      expect(user.errors[:name]).to include("を入力してください")
     end
 
     it 'メールアドレスがなければ無効な状態であること' do
       user = build(:user, email: '')
       user.valid?
-      expect(user.errors[:email]).to include("can't be blank")
+      expect(user.errors[:email]).to include('を入力してください')
     end
 
     it 'パスワードが2文字では無効な状態であること' do
       user = build(:user, password: 'fo')
       user.valid?
-      expect(user.errors[:password]).to include('is too short (minimum is 3 characters)')
+      expect(user.errors[:password]).to include('は3文字以上で入力してください')
     end
 
     it 'パスワードが3文字あれば有効な状態であること' do
       user = build(:user, password: 'foo')
       user.valid?
-      expect(user.errors[:password]).not_to include('is too short (minimum is 3 characters)')
+      expect(user.errors[:password]).not_to include('iは3文字以上で入力してください')
     end
 
     it '重複するメールアドレスは無効であること' do
       user = create(:user)
       another_user = build(:user, email: user.email)
       another_user.valid?
-      expect(another_user.errors[:email]).to include('has already been taken')
+      expect(another_user.errors[:email]).to include('はすでに存在します')
     end
 
     it '身長が未入力では更新できないこと' do
       user = create(:user)
       user.height = ''
       user.valid?
-      expect(user.errors[:height]).to include("can't be blank")
+      expect(user.errors[:height]).to include('を入力してください')
     end
 
     it '体重が未入力では更新できないこと' do
       user = create(:user)
       user.body_weight = ''
       user.valid?
-      expect(user.errors[:body_weight]).to include("can't be blank")
+      expect(user.errors[:body_weight]).to include('を入力してください')
     end
 
     it '年齢が未入力では更新できないこと' do
       user = create(:user)
       user.age = ''
       user.valid?
-      expect(user.errors[:age]).to include("can't be blank")
+      expect(user.errors[:age]).to include('を入力してください')
     end
 
     it '性別が未入力では更新できないこと' do
       user = create(:user)
       user.sex = ''
       user.valid?
-      expect(user.errors[:sex]).to include("can't be blank")
+      expect(user.errors[:sex]).to include('を入力してください')
     end
 
     it '活動レベルが未入力では更新できないこと' do
       user = create(:user)
       user.active_level = ''
       user.valid?
-      expect(user.errors[:active_level]).to include("can't be blank")
+      expect(user.errors[:active_level]).to include('を入力してください')
     end
   end
 end

--- a/spec/support/login_support.rb
+++ b/spec/support/login_support.rb
@@ -1,9 +1,9 @@
 module LoginSupport
   def login_as(user)
     visit root_path
-    click_link 'Login'
-    fill_in 'Email', with: user.email
-    fill_in 'Password', with: 'password'
+    click_link 'ログイン'
+    fill_in 'メールアドレス', with: user.email
+    fill_in 'パスワード', with: 'password'
     click_button 'ログイン'
   end
 end

--- a/spec/system/profiles_spec.rb
+++ b/spec/system/profiles_spec.rb
@@ -6,11 +6,11 @@ RSpec.describe 'Profiles' do
   it 'プロフィール登録するすると、メンテナンスカロリーと目標カロリーが登録され、表示されること' do
     login_as(user)
     visit edit_profile_path
-    fill_in 'Height', with: user.height
-    fill_in 'Body weight', with: user.body_weight
-    fill_in 'Age', with: user.age
-    select 'male', from: 'Sex'
-    select 'level1', from: 'Active level'
+    fill_in '身長', with: user.height
+    fill_in '体重', with: user.body_weight
+    fill_in '年齢', with: user.age
+    select '男', from: 'Sex'
+    select 'レベル1', from: 'Active level'
     click_button '計算する'
     expect(page).to have_content 'あなたの目標摂取カロリーは１日あたり'
     expect(page).to have_current_path edit_profile_path, ignore_query: true

--- a/spec/system/profiles_spec.rb
+++ b/spec/system/profiles_spec.rb
@@ -9,8 +9,8 @@ RSpec.describe 'Profiles' do
     fill_in '身長', with: user.height
     fill_in '体重', with: user.body_weight
     fill_in '年齢', with: user.age
-    select '男', from: 'Sex'
-    select 'レベル1', from: 'Active level'
+    select '男性', from: '生まれた時の性別'
+    select 'レベル1', from: '活動量'
     click_button '計算する'
     expect(page).to have_content 'あなたの目標摂取カロリーは１日あたり'
     expect(page).to have_current_path edit_profile_path, ignore_query: true

--- a/spec/system/user_sessions_spec.rb
+++ b/spec/system/user_sessions_spec.rb
@@ -7,8 +7,8 @@ RSpec.describe 'UserSessions' do
     context 'フォームの入力値が正常' do
       it 'ログイン処理が成功する' do
         visit login_path
-        fill_in 'Email', with: user.email
-        fill_in 'Password', with: 'password'
+        fill_in 'メールアドレス', with: user.email
+        fill_in 'パスワード', with: 'password'
         click_button 'ログイン'
         expect(page).to have_content 'ログインしました'
         expect(page).to have_current_path profile_path, ignore_query: true
@@ -18,8 +18,8 @@ RSpec.describe 'UserSessions' do
     context 'フォームが未入力' do
       it 'ログイン処理が失敗する' do
         visit login_path
-        fill_in 'Email', with: ''
-        fill_in 'Password', with: 'password'
+        fill_in 'メールアドレス', with: ''
+        fill_in 'パスワード', with: 'password'
         click_button 'ログイン'
         expect(page).to have_content 'emailかパスワードが間違っています'
         expect(page).to have_current_path login_path, ignore_query: true

--- a/spec/system/user_sessions_spec.rb
+++ b/spec/system/user_sessions_spec.rb
@@ -21,7 +21,7 @@ RSpec.describe 'UserSessions' do
         fill_in 'メールアドレス', with: ''
         fill_in 'パスワード', with: 'password'
         click_button 'ログイン'
-        expect(page).to have_content 'emailかパスワードが間違っています'
+        expect(page).to have_content 'ログインに失敗しました（メールアドレスかパスワードが間違っています）'
         expect(page).to have_current_path login_path, ignore_query: true
       end
     end

--- a/spec/system/users_spec.rb
+++ b/spec/system/users_spec.rb
@@ -12,7 +12,7 @@ RSpec.describe 'Users' do
         fill_in 'パスワード', with: 'password'
         fill_in 'パスワード（確認用）', with: 'password'
         click_button '登録'
-        expect(page).to have_content '登録しました'
+        expect(page).to have_content 'ユーザー登録が完了しました'
         expect(page).to have_current_path login_path, ignore_query: true
       end
     end
@@ -25,7 +25,7 @@ RSpec.describe 'Users' do
         fill_in 'パスワード', with: 'password'
         fill_in 'パスワード（確認用）', with: 'password'
         click_button '登録'
-        expect(page).to have_content '登録できませんでした'
+        expect(page).to have_content 'ユーザー登録に失敗しました'
         expect(page).to have_content '名前を入力してください'
         expect(page).to have_current_path users_path, ignore_query: true
       end
@@ -39,7 +39,7 @@ RSpec.describe 'Users' do
         fill_in 'パスワード', with: 'password'
         fill_in 'パスワード（確認用）', with: 'password'
         click_button '登録'
-        expect(page).to have_content '登録できませんでした'
+        expect(page).to have_content 'ユーザー登録に失敗しました'
         expect(page).to have_content 'メールアドレスを入力してください'
         expect(page).to have_current_path users_path, ignore_query: true
       end
@@ -53,7 +53,7 @@ RSpec.describe 'Users' do
         fill_in 'パスワード', with: ''
         fill_in 'パスワード（確認用）', with: 'password'
         click_button '登録'
-        expect(page).to have_content '登録できませんでした'
+        expect(page).to have_content 'ユーザー登録に失敗しました'
         expect(page).to have_content 'パスワードは3文字以上で入力してください'
         expect(page).to have_current_path users_path, ignore_query: true
       end
@@ -67,7 +67,7 @@ RSpec.describe 'Users' do
         fill_in 'パスワード', with: 'password'
         fill_in 'パスワード（確認用）', with: ''
         click_button '登録'
-        expect(page).to have_content '登録できませんでした'
+        expect(page).to have_content 'ユーザー登録に失敗しました'
         expect(page).to have_content 'パスワード（確認用）を入力してください'
         expect(page).to have_current_path users_path, ignore_query: true
       end
@@ -82,7 +82,7 @@ RSpec.describe 'Users' do
         fill_in 'パスワード', with: 'password'
         fill_in 'パスワード（確認用）', with: 'password'
         click_button '登録'
-        expect(page).to have_content '登録できませんでした'
+        expect(page).to have_content 'ユーザー登録に失敗しました'
         expect(page).to have_content 'メールアドレスはすでに存在します'
         expect(page).to have_current_path users_path, ignore_query: true
       end
@@ -97,7 +97,7 @@ RSpec.describe 'Users' do
         fill_in 'パスワード', with: 'password'
         fill_in 'パスワード（確認用）', with: 'foobar'
         click_button '登録'
-        expect(page).to have_content '登録できませんでした'
+        expect(page).to have_content 'ユーザー登録に失敗しました'
         expect(page).to have_content 'パスワード（確認用）とパスワードの入力が一致しません'
         expect(page).to have_current_path users_path, ignore_query: true
       end

--- a/spec/system/users_spec.rb
+++ b/spec/system/users_spec.rb
@@ -54,10 +54,10 @@ RSpec.describe 'Users' do
       it 'ユーザーの新規作成が失敗する' do
         existed_user = create(:user)
         visit new_user_path
-        fill_in 'Name', with: 'Example'
+        fill_in '名前', with: 'Example'
         fill_in 'Email', with: existed_user.email
-        fill_in 'Password', with: 'password'
-        fill_in 'Password confirmation', with: 'foobar'
+        fill_in 'パスワード', with: 'password'
+        fill_in 'パスワード（確認用）', with: 'foobar'
         click_button '登録する'
         expect(page).to have_content '登録できませんでした'
         expect(page).to have_content "Password confirmation doesn't match Password"

--- a/spec/system/users_spec.rb
+++ b/spec/system/users_spec.rb
@@ -1,36 +1,74 @@
 require 'rails_helper'
 
 RSpec.describe 'Users' do
-  before do
-    driven_by(:rack_test)
-  end
-
   let(:user) { create(:user) }
 
   describe 'ユーザー新規登録' do
     context 'フォームの入力値が正常' do
       it 'ユーザーの新規作成が成功する' do
         visit new_user_path
-        fill_in 'Name', with: 'Example'
-        fill_in 'Email', with: 'email@example.com'
-        fill_in 'Password', with: 'password'
-        fill_in 'Password confirmation', with: 'password'
-        click_button '登録する'
+        fill_in '名前', with: 'Example'
+        fill_in 'メールアドレス', with: 'email@example.com'
+        fill_in 'パスワード', with: 'password'
+        fill_in 'パスワード（確認用）', with: 'password'
+        click_button '登録'
         expect(page).to have_content '登録しました'
         expect(page).to have_current_path login_path, ignore_query: true
+      end
+    end
+
+    context '名前が未入力' do
+      it 'ユーザーの新規作成が失敗する' do
+        visit new_user_path
+        fill_in '名前', with: ''
+        fill_in 'メールアドレス', with: 'example@example.com'
+        fill_in 'パスワード', with: 'password'
+        fill_in 'パスワード（確認用）', with: 'password'
+        click_button '登録'
+        expect(page).to have_content '登録できませんでした'
+        expect(page).to have_content '名前を入力してください'
+        expect(page).to have_current_path users_path, ignore_query: true
       end
     end
 
     context 'メールアドレスが未入力' do
       it 'ユーザーの新規作成が失敗する' do
         visit new_user_path
-        fill_in 'Name', with: 'Example'
-        fill_in 'Email', with: ''
-        fill_in 'Password', with: 'password'
-        fill_in 'Password confirmation', with: 'password'
-        click_button '登録する'
+        fill_in '名前', with: 'Example'
+        fill_in 'メールアドレス', with: ''
+        fill_in 'パスワード', with: 'password'
+        fill_in 'パスワード（確認用）', with: 'password'
+        click_button '登録'
         expect(page).to have_content '登録できませんでした'
-        expect(page).to have_content "Email can't be blank"
+        expect(page).to have_content 'メールアドレスを入力してください'
+        expect(page).to have_current_path users_path, ignore_query: true
+      end
+    end
+
+    context 'パスワードが未入力' do
+      it 'ユーザーの新規作成が失敗する' do
+        visit new_user_path
+        fill_in '名前', with: 'Example'
+        fill_in 'メールアドレス', with: 'example@example.com'
+        fill_in 'パスワード', with: ''
+        fill_in 'パスワード（確認用）', with: 'password'
+        click_button '登録'
+        expect(page).to have_content '登録できませんでした'
+        expect(page).to have_content 'パスワードは3文字以上で入力してください'
+        expect(page).to have_current_path users_path, ignore_query: true
+      end
+    end
+
+    context 'パスワード（確認用）が未入力' do
+      it 'ユーザーの新規作成が失敗する' do
+        visit new_user_path
+        fill_in '名前', with: 'Example'
+        fill_in 'メールアドレス', with: 'example@example.com'
+        fill_in 'パスワード', with: 'password'
+        fill_in 'パスワード（確認用）', with: ''
+        click_button '登録'
+        expect(page).to have_content '登録できませんでした'
+        expect(page).to have_content 'パスワード（確認用）を入力してください'
         expect(page).to have_current_path users_path, ignore_query: true
       end
     end
@@ -39,13 +77,13 @@ RSpec.describe 'Users' do
       it 'ユーザーの新規作成が失敗する' do
         existed_user = create(:user)
         visit new_user_path
-        fill_in 'Name', with: 'Example'
-        fill_in 'Email', with: existed_user.email
-        fill_in 'Password', with: 'password'
-        fill_in 'Password confirmation', with: 'password'
-        click_button '登録する'
+        fill_in '名前', with: 'Example'
+        fill_in 'メールアドレス', with: existed_user.email
+        fill_in 'パスワード', with: 'password'
+        fill_in 'パスワード（確認用）', with: 'password'
+        click_button '登録'
         expect(page).to have_content '登録できませんでした'
-        expect(page).to have_content 'Email has already been taken'
+        expect(page).to have_content 'メールアドレスはすでに存在します'
         expect(page).to have_current_path users_path, ignore_query: true
       end
     end
@@ -55,12 +93,12 @@ RSpec.describe 'Users' do
         existed_user = create(:user)
         visit new_user_path
         fill_in '名前', with: 'Example'
-        fill_in 'Email', with: existed_user.email
+        fill_in 'メールアドレス', with: existed_user.email
         fill_in 'パスワード', with: 'password'
         fill_in 'パスワード（確認用）', with: 'foobar'
-        click_button '登録する'
+        click_button '登録'
         expect(page).to have_content '登録できませんでした'
-        expect(page).to have_content "Password confirmation doesn't match Password"
+        expect(page).to have_content 'パスワード（確認用）とパスワードの入力が一致しません'
         expect(page).to have_current_path users_path, ignore_query: true
       end
     end


### PR DESCRIPTION
## 概要

`rails-i18n`gemの導入や、辞書ファイルの追加によりビューの日本語化対応をしました。


## 確認方法

1. Gem を追加したので `bundle install` を実行してください
2. RSpecのテストが全てパスすることを確認してください。
3. ブラウザにてユーザー登録画面、ログイン画面、プロフィール編集画面のフォームが日本語化されていることを確認してください。

## 影響範囲
作成したビュー全体に影響します。


## チェックリスト

- [x] 必要なテストを追加した
- [x] Lint のチェックをパスした
- [x] テストを全てパスした

## コメント
- フッターについてはリンク先URLを設定するときにi18n対応
- 今後はビューファイルを作成する際にi18n対応することとする

