### PR TITLE
[User destroy#39] ユーザー退会機能(destroy)の実装

### DIFF
--- a/app/controllers/profiles_controller.rb
+++ b/app/controllers/profiles_controller.rb
@@ -23,7 +23,7 @@ class ProfilesController < ApplicationController
 
   def destroy
     @user.destroy!
-    redirect_to root_path, success: '退会しました', status: :see_other
+    redirect_to root_path, success: t('.success'), status: :see_other
   end
 
   private

--- a/app/controllers/profiles_controller.rb
+++ b/app/controllers/profiles_controller.rb
@@ -1,5 +1,5 @@
 class ProfilesController < ApplicationController
-  before_action :set_user, only: %i[edit update show]
+  before_action :set_user, only: %i[edit update show destroy]
 
   def show; end
   def edit; end
@@ -19,6 +19,11 @@ class ProfilesController < ApplicationController
       flash.now['danger'] = t('.fail')
       render :edit, status: :unprocessable_entity
     end
+  end
+
+  def destroy
+    @user.destroy!
+    redirect_to root_path, success: '退会しました', status: :see_other
   end
 
   private

--- a/app/views/profiles/show.html.erb
+++ b/app/views/profiles/show.html.erb
@@ -44,6 +44,6 @@
   <%= link_to '編集する', edit_profile_path %>
 </div>
 <div class="btn btn-secondary flex justify-center">
-  <%= link_to '退会する', profile_path, data: { turbo_method: :delete, turbo_confirm: '本当に退会しますか?' } %>
+  <%= link_to (t 'profiles.destroy.delete_an_account'), profile_path, data: { turbo_method: :delete, turbo_confirm: '本当に退会しますか?' } %>
 </div>
 

--- a/app/views/profiles/show.html.erb
+++ b/app/views/profiles/show.html.erb
@@ -43,3 +43,7 @@
 <div class="btn btn-primary flex justify-center">
   <%= link_to '編集する', edit_profile_path %>
 </div>
+<div class="btn btn-secondary flex justify-center">
+  <%= link_to '退会する', profile_path, data: { turbo_method: :delete, turbo_confirm: '本当に退会しますか?' } %>
+</div>
+

--- a/config/locales/views/ja.yml
+++ b/config/locales/views/ja.yml
@@ -31,3 +31,6 @@ ja:
     update:
       success: "プロフィールを更新しました"
       fail: "更新できませんでした"
+    destroy:
+      success: "退会しました"
+      delete_an_account: "退会する"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -5,5 +5,5 @@ Rails.application.routes.draw do
   delete 'logout', to: 'user_sessions#destroy'
 
   resources :users, only: %i[show new create]
-  resource :profile, only: %i[show edit update]
+  resource :profile, only: %i[show edit update destroy]
 end

--- a/spec/system/profiles_spec.rb
+++ b/spec/system/profiles_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-RSpec.describe 'Profiles' do
+RSpec.describe 'Profiles', js: true do
   let(:user) { create(:user) }
 
   it 'プロフィール登録すると、プロフィール表示画面に遷移し、情報が表示されること' do
@@ -14,5 +14,16 @@ RSpec.describe 'Profiles' do
     click_button '更新する'
     expect(page).to have_content 'プロフィールを更新しました'
     expect(page).to have_current_path profile_path, ignore_query: true
+  end
+
+  it 'プロフィールの退会するボタンをクリックすると確認メッセージが表示されてからユーザーが削除されること' do
+    login_as(user)
+    visit profile_path
+    page.accept_confirm do
+      click_on '退会する'
+    end
+    expect(page).to have_content '退会しました'
+    expect(page).to have_content 'ログイン'
+    expect(page).to have_current_path root_path, ignore_query: true
   end
 end


### PR DESCRIPTION
## 概要
- ユーザー表示画面(show)から退会できるよう、退会ボタンを設置
- 確認表示(confirm)でOKを押すとdestroyアクションが発火するように実装

## 確認方法

1. ログイン後のプロフィール表示画面中、「退会する」ボタンをクリックする
2. 確認ダイアログのOKをクリック
3. トップページにリダイレクトし、フラッシュメッセージ「退会しました」が表示
4. システムテストをパスすること

## 影響範囲
プロフィール表示画面

## チェックリスト

- [x] Lint のチェックをパスした
- [x] システムテストをパスした

## コメント
- 退会機能は暫定的にプロフィール表示に実装したが、今後使い勝手のいいページに修正する可能性あり
close #39 