### PR TITLE
[質問] テスト環境と本番環境でチェックボックスのフォームが表示されない #70

### DIFF
--- a/app/models/type_array.rb
+++ b/app/models/type_array.rb
@@ -1,5 +1,5 @@
-class TypeArray < ActiveModel::Type::Value
-  def cast_value(value)
-    value
-  end
-end
+# class TypeArray < ActiveModel::Type::Value
+#   def cast_value(value)
+#     value
+#   end
+# end

--- a/config/initializers/types.rb
+++ b/config/initializers/types.rb
@@ -1,4 +1,7 @@
-#require 'active_model/type'
-Rails.application.config.to_prepare do
-  ActiveModel::Type.register(:array, TypeArray)
+class TypeArray < ActiveModel::Type::Value
+  def cast_value(value)
+    value
+  end
 end
+
+ActiveModel::Type.register(:array, TypeArray)

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -5,3 +5,18 @@
 #
 #   movies = Movie.create([{ name: "Star Wars" }, { name: "Lord of the Rings" }])
 #   Character.create(name: "Luke", movie: movies.first)
+BodyPart.create!(
+  body_part_name: "胸"
+)
+BodyPart.create!(
+  body_part_name: "肩"
+)
+BodyPart.create!(
+  body_part_name: "背中"
+)
+BodyPart.create!(
+  body_part_name: "腕"
+)
+BodyPart.create!(
+  body_part_name: "脚"
+)

--- a/spec/system/workout_forms_spec.rb
+++ b/spec/system/workout_forms_spec.rb
@@ -3,7 +3,7 @@ require 'rails_helper'
 RSpec.describe 'WorkoutForms' do
   let(:user) { create(:user) }
 
-  xit '新規筋トレ投稿画面から筋トレの記録（種目名、トレーニング時間、重量、回数、セット数）を登録できること' do
+  it '新規筋トレ投稿画面から筋トレの記録（種目名、トレーニング時間、重量、回数、セット数）を登録できること' do
     login_as(user)
     visit new_workout_path
     fill_in '筋トレ日', with: '2022-12-18 14:33:52'


### PR DESCRIPTION
## 質問内容・実現したいこと
- 筋トレの投稿機能を実装中です。具体的には、筋トレで鍛えられる部位をチェックボックスで複数個、配列で受け取ってそれを筋トレ投稿に対して紐づける処理を書いています。
- テーブル設計は以下のとおりです。筋トレ投稿(workoutsテーブル)、筋トレで鍛えられる体の部位(body_partsテーブル)、これらを多：多で関連づけるための中間テーブル(workout_body_partsテーブル)
![質問用1](https://user-images.githubusercontent.com/26403599/208916504-a27ecdb0-bc4a-497d-9b0d-0c3ce48e03d4.png)
- 開発環境ではフォーム中のチェックボックスが表示されているのに、テスト環境と本番環境でチェックボックスが表示されないため、表示されるようにしたいです。
### 開発環境
<img width="1224" alt="質問用2" src="https://user-images.githubusercontent.com/26403599/208917507-ecb1ac6d-1159-4957-90df-215a31000637.png">

### テスト（cssセレクターが表示されないため、システムテストが失敗する）

<img width="1099" alt="質問用3" src="https://user-images.githubusercontent.com/26403599/208918014-8e67715a-17df-44c0-a9bc-e457c4846698.png">

### 本番環境（Herokuにデプロイできるものの、テスト環境同様チェックボックスが表示されていません）
<img width="1215" alt="質問用4" src="https://user-images.githubusercontent.com/26403599/208918199-406c833b-4ada-4820-afe8-c72aab76b3ff.png">

## 現状発生している問題・エラーメッセージ
- RSpecのテスト環境でシステムスペックを走らせると以下のようにテストが失敗します。
```
RSpec.describe 'WorkoutForms' do
  let(:user) { create(:user) }

  it '新規筋トレ投稿画面から筋トレの記録（種目名、トレーニング時間、重量、回数、セット数）を登録できること' do
    login_as(user)
    visit new_workout_path
    fill_in '筋トレ日', with: '2022-12-18 14:33:52'
    fill_in '種目名', with: 'ベンチプレス'
    check '胸'
    fill_in 'トレーニーング時間(分)', with: '30'
    fill_in '重量', with: '80.5'
    fill_in '回数', with: '10'
    fill_in 'セット数', with: '3'
    click_button '投稿する'
    expect(page).to have_content '筋トレ投稿を作成しました'
    expect(page).to have_current_path user_path(user), ignore_query: true
  end
end
```
#=>
```
Capybara::ElementNotFound:
       Unable to find checkbox "胸" that is not disabled
```
- 本番環境でも上の写真のようにチェックボックスが表示されていません。

## どの処理までうまく動いているのか
- 開発環境では上の写真のように表示されています。
- テスト環境も、開発環境もラベルの文字列表示はできているようです。


## 該当のソースコード
app/views/workouts/new.html.erb
```
<div class="container mx-auto px-8 w-full">
  <h1 class="text-5xl font-bold"><%= t '.title' %></h1>
  <%= form_with model: @workout_form, url: workouts_path, local: true do |f| %>
  <%= render 'shared/error_messages', object: f.object %>
    <div class="form-control">
      <%= f.label :workout_date %>
      <%= f.date_field :workout_date, class: "input input-bordered" %>
    </div>
    <div class="form-control">
      <%= f.label :workout_title %>
      <%= f.text_field :workout_title, class: "input input-bordered" %>
    </div>
    <div class="form-control">
      <%= f.label :body_part_ids %>
      <%= f.collection_check_boxes(:body_part_ids, BodyPart.all, :id, :body_part_name, {include_hidden: false}, {class: "checkbox"}) do |body_part| %>
        <%= body_part.label { body_part.check_box + body_part.text }%>
      <% end%>
    </div>
    <div class="form-control">
      <%= f.label :workout_time %>
      <%= f.number_field :workout_time, class: "input input-bordered" %>
    </div>
    <div class="form-control">
      <%= f.label :workout_weight %>
      <%= f.number_field :workout_weight, class: "input input-bordered" %>
    </div>
    <div class="form-control">
      <%= f.label :repetition_count %>
      <%= f.number_field :repetition_count, class: "input input-bordered" %>
    </div>
    <div class="form-control">
      <%= f.label :set_count %>
      <%= f.number_field :set_count, class: "input input-bordered" %>
    </div>
    <div class="form-control">
      <%= f.label :workout_memo %>
      <%= f.text_area :workout_memo, class: "input input-bordered" %>
    </div>
    <div class="form-control mt-6">
      <%= f.submit '投稿する', class: "btn btn-primary"%>
    </div>
    <% end %>
  </div>
</div>
```
このフォームは、フォームオブジェクト（workout_form.rb）より生成したものです。（親`workoutテーブル`と子`workout_body_parts中間テーブル`の両方を同時に保存する必要があるため、フォームオブジェクトで実装しました。）

app/forms/forkout_form.rb
```
class WorkoutForm
  include ActiveModel::Model
  include ActiveModel::Attributes

  attribute :workout_date, :datetime
  attribute :workout_title, :string
  attribute :workout_time, :integer
  attribute :workout_weight, :float
  attribute :repetition_count, :integer
  attribute :set_count, :integer
  attribute :workout_memo, :string
  attribute :body_part_ids, :array
  attribute :user_id, :integer
  attribute :workout_id, :integer

  validates :workout_date, presence: true
  validates :workout_title, presence: true
  validates :body_part_ids, presence: true
  validates :workout_time, presence: true
  validates :workout_weight, presence: true
  validates :repetition_count, presence: true
  validates :set_count, presence: true

  def save
    return false if invalid?

    workout = Workout.create(workout_date:, workout_title:, workout_time:,
                             workout_weight:, repetition_count:, set_count:, workout_memo:, user_id:)
    body_part_ids.map(&:to_i).each do |body_part_id|
      WorkoutBodyPart.create(workout_id: workout.id, body_part_id:)
    end
  end
end

```
また、`:body_part_ids`は配列で受け取りたかったため、以下のリンク先を参考にActiveModelにカスタムモデルを定義して、array型を実装しています。
- https://wat-aro.hatenablog.com/entry/2018/08/07/203114
- https://40yd.app/blog/rails-active-model-attribute
- https://gitpress.io/@rhiroe/active_model_attributes

config/initializers/types.rb
```
class TypeArray < ActiveModel::Type::Value
  def cast_value(value)
    value
  end
end

ActiveModel::Type.register(:array, TypeArray)
```

## エラーから考えられる原因
- `config/initializers/types.rb`がテスト環境と本番環境でうまく読み込まれていない？
- `f.collection_check_boxes`が環境差異で読み込んでない？
- あるいは単にCSSが当たっていない？

## 試したこと
- サーバーの再起動やテスト環境のDBリセット（`bundle exec rails db:migrate:reset RAILS_ENV=test `）は念のため、実施してみましたが変化ありませんでした。

close #70 