### PR TITLE
[Change time zone#64] アプリのタイムゾーン設定

### DIFF
--- a/app/views/workouts/show.html.erb
+++ b/app/views/workouts/show.html.erb
@@ -1,4 +1,4 @@
-<h1 class="text-5xl font-bold"><%= @workout.workout_date %></h1>
+<h1 class="text-5xl font-bold"><%= @workout.workout_date.strftime("%Y年%m月%d日") %></h1>
 <h1 class="text-5xl font-bold"><%= @workout.workout_title %></h1>
 <h1 class="text-5xl font-bold"><%= @workout.body_parts.pluck(:body_part_name) %></h1>
 <h1 class="text-5xl font-bold">id <%= params[:id] %></h1>

--- a/config/application.rb
+++ b/config/application.rb
@@ -22,6 +22,7 @@ module TrainingAndMeals
   class Application < Rails::Application
     # Initialize configuration defaults for originally generated Rails version.
     config.load_defaults 7.0
+    config.time_zone = 'Asia/Tokyo'
 
     # Configuration for the application, engines, and railties goes here.
     #


### PR DESCRIPTION
## 概要
- アプリのタイムゾーン設定を日本時間に修正しました
- データベース上はUTC、アプリ上はJSTとなるように、アプリ起動時の時刻設定ファイルを修正しています
- 筋トレ投稿の表示(show.html.erb)の表記を`strftime`メソッドにより修正

## 確認方法

1. サーバーを再起動して`rails console` から日本時間で表示されることを確認
2. 筋トレ投稿の表示画面が日時表示のみとなったことを確認

## 影響範囲
アプリ全体の時刻設定がJSTとなります。


## チェックリスト
- [ ] Lint のチェックをパスした
- [ ] テストをパスした

## コメント
- 筋トレ投稿表示画面のレイアウトは後日修正
close #64 