### PR TITLE
[Add actions to meals#75] 食事投稿機能のshow, edit, update, destroyアクション実装

### DIFF
--- a/app/controllers/meals_controller.rb
+++ b/app/controllers/meals_controller.rb
@@ -1,5 +1,6 @@
 class MealsController < ApplicationController
-  before_action :set_user, only: %i[new create]
+  before_action :set_user, only: %i[new create show edit update destroy]
+  before_action :set_meal, only: %i[show edit destroy]
 
   def new
     @meal_form = MealForm.new
@@ -15,6 +16,28 @@ class MealsController < ApplicationController
     end
   end
 
+  def show ;end
+
+  def edit
+    @meal_form = Meal.find(params[:id])
+  end
+
+  def update
+    @meal_form = MealForm.new(meal_params)
+
+    if @meal_form.update
+      redirect_to user_path(@user.id), success: t('defaults.message.updated', item: Meal.model_name.human)
+    else
+      flash.now['danger'] = t('defaults.message.not_updated', item: Meal.model_name.human)
+      render :edit, status: :unprocessable_entity
+    end
+  end
+
+  def destroy
+    @meal.destroy!
+    redirect_to user_path(@user.id), success: t('defaults.message.deleted', item: Meal.model_name.human)
+  end
+
   private
 
   def meal_form_params
@@ -24,7 +47,18 @@ class MealsController < ApplicationController
                                       :meal_title_third, :meal_weight_third, :meal_calorie_third).merge(user_id: current_user.id)
   end
 
+  def meal_params
+    params.require(:meal).permit(:meal_period, :meal_type, :meal_memo,
+                                      :meal_title_first, :meal_weight_first, :meal_calorie_first,
+                                      :meal_title_second, :meal_weight_second, :meal_calorie_second,
+                                      :meal_title_third, :meal_weight_third, :meal_calorie_third).merge(user_id: current_user.id, meal_id: params[:id])
+  end
+
   def set_user
     @user = User.find(current_user.id)
+  end
+
+  def set_meal
+    @meal = current_user.meals.find(params[:id])
   end
 end

--- a/app/controllers/meals_controller.rb
+++ b/app/controllers/meals_controller.rb
@@ -28,6 +28,7 @@ class MealsController < ApplicationController
     if @meal_form.update
       redirect_to user_path(@user.id), success: t('defaults.message.updated', item: Meal.model_name.human)
     else
+      debugger
       flash.now['danger'] = t('defaults.message.not_updated', item: Meal.model_name.human)
       render :edit, status: :unprocessable_entity
     end

--- a/app/controllers/meals_controller.rb
+++ b/app/controllers/meals_controller.rb
@@ -2,8 +2,14 @@ class MealsController < ApplicationController
   before_action :set_user, only: %i[new create show edit update destroy]
   before_action :set_meal, only: %i[show edit destroy]
 
+  def show; end
+
   def new
     @meal_form = MealForm.new
+  end
+
+  def edit
+    @meal_form = Meal.find(params[:id])
   end
 
   def create
@@ -16,19 +22,12 @@ class MealsController < ApplicationController
     end
   end
 
-  def show ;end
-
-  def edit
-    @meal_form = Meal.find(params[:id])
-  end
-
   def update
     @meal_form = MealForm.new(meal_params)
 
     if @meal_form.update
       redirect_to user_path(@user.id), success: t('defaults.message.updated', item: Meal.model_name.human)
     else
-      debugger
       flash.now['danger'] = t('defaults.message.not_updated', item: Meal.model_name.human)
       render :edit, status: :unprocessable_entity
     end
@@ -50,9 +49,9 @@ class MealsController < ApplicationController
 
   def meal_params
     params.require(:meal).permit(:meal_period, :meal_type, :meal_memo,
-                                      :meal_title_first, :meal_weight_first, :meal_calorie_first,
-                                      :meal_title_second, :meal_weight_second, :meal_calorie_second,
-                                      :meal_title_third, :meal_weight_third, :meal_calorie_third).merge(user_id: current_user.id, meal_id: params[:id])
+                                 :meal_title_first, :meal_weight_first, :meal_calorie_first,
+                                 :meal_title_second, :meal_weight_second, :meal_calorie_second,
+                                 :meal_title_third, :meal_weight_third, :meal_calorie_third).merge(user_id: current_user.id, meal_id: params[:id])
   end
 
   def set_user

--- a/app/forms/meal_form.rb
+++ b/app/forms/meal_form.rb
@@ -37,6 +37,23 @@ class MealForm
                               meal_calorie: meal_calorie_third).save
     end
     meal
-    # MealDetail.create(meal_title:, meal_weight:, meal_calorie:, meal_id: meal.id)
+  end
+
+  def update
+    return false if invalid?
+
+    meal = Meal.find(meal_id)
+    meal.update!(meal_period:, meal_type:, meal_memo:, user_id:)
+    MealDetail.where(meal_id: meal.id).delete_all
+    meal.meal_details.build(meal_title: meal_title_first, meal_weight: meal_weight_first, meal_calorie: meal_calorie_first).save
+    if meal_title_second.present?
+      meal.meal_details.build(meal_title: meal_title_second, meal_weight: meal_weight_second,
+                              meal_calorie: meal_calorie_second).save
+    end
+    if meal_title_third.present?
+      meal.meal_details.build(meal_title: meal_title_third, meal_weight: meal_weight_third,
+                              meal_calorie: meal_calorie_third).save
+    end
+    meal
   end
 end

--- a/app/views/meals/_meal.html.erb
+++ b/app/views/meals/_meal.html.erb
@@ -2,9 +2,9 @@
   <div class="card w-96 bg-base-100 shadow-xl">
     <div class="card-body">
       <h4 class="card-title">
-        <%= meal.meal_period_i18n %>
+        <%= link_to meal.meal_period_i18n, meal_path(meal.id) %>
       </h4>
-      <h4><%= link_to meal.meal_details.pluck(:meal_title).join(','), "#" %></h4>
+      <h4><%= meal.meal_details.pluck(:meal_title).join(',')%></h4>
       <p><%= meal.meal_details.pluck(:meal_calorie).sum %>kcal</p>
     </div>
   </div>

--- a/app/views/meals/edit.html.erb
+++ b/app/views/meals/edit.html.erb
@@ -63,7 +63,7 @@
     </div>
   <% end %>
     <div class="btn btn-secondary flex justify-center">
-      <%= link_to (t 'meals.destroy.delete_a_meal'), meal_path(@meal), data: { turbo_method: :delete, turbo_confirm: '本当に削除しますか?' } %>
+      <%= link_to (t 'meals.destroy.delete_a_meal'), meal_path(params[:id]), data: { turbo_method: :delete, turbo_confirm: '本当に削除しますか?' } %>
     </div>
   </div>
 </div>

--- a/app/views/meals/edit.html.erb
+++ b/app/views/meals/edit.html.erb
@@ -1,0 +1,69 @@
+<div class="container mx-auto px-8 w-full">
+<h1 class="text-5xl font-bold"><%= t '.title' %></h1>
+  <%= form_with model: @meal_form, url: meal_path, local: true do |f| %>
+  <%= render 'shared/error_messages', object: f.object %>
+    <div class="form-control">
+      <%= f.label :meal_period %>
+      <%= f.select :meal_period, Meal.meal_periods_i18n.invert.map{|key, value| [key, Meal.meal_periods[value]]}, class: "input input-bordered" %>
+    </div>
+    <div class="form-control">
+      <%= f.label :meal_type %>
+      <%= f.select :meal_type, Meal.meal_types_i18n.invert.map{|key, value| [key, Meal.meal_types[value]]}, class: "input input-bordered" %>
+    </div>
+    <div class="flex">
+      <div class="flex-col">
+        <div class="form-control">
+          <%= f.label :meal_title_first %>
+          <%= f.text_field :meal_title_first, class: "input input-bordered" %>
+        </div>
+        <div class="form-control">
+          <%= f.label :meal_weight_first %>
+          <%= f.number_field :meal_weight_first, class: "input input-bordered" %>
+        </div>
+        <div class="form-control">
+          <%= f.label :meal_calorie_first %>
+          <%= f.number_field :meal_calorie_first, class: "input input-bordered" %>
+        </div>
+      </div>
+      <div class="flex-col">
+        <div class="form-control mt-6">
+          <%= f.label :meal_title_second %>
+          <%= f.text_field :meal_title_second, class: "input input-bordered" %>
+        </div>
+        <div class="form-control">
+          <%= f.label :meal_weight_second %>
+          <%= f.number_field :meal_weight_second, class: "input input-bordered" %>
+        </div>
+        <div class="form-control">
+          <%= f.label :meal_calorie_second %>
+          <%= f.number_field :meal_calorie_second, class: "input input-bordered" %>
+        </div>
+      </div>
+      <div class="flex-col">
+        <div class="form-control mt-6">
+          <%= f.label :meal_title_third %>
+          <%= f.text_field :meal_title_third, class: "input input-bordered" %>
+        </div>
+        <div class="form-control">
+          <%= f.label :meal_weight_third %>
+          <%= f.number_field :meal_weight_third, class: "input input-bordered" %>
+        </div>
+        <div class="form-control">
+          <%= f.label :meal_calorie_third %>
+          <%= f.number_field :meal_calorie_third, class: "input input-bordered" %>
+        </div>
+      </div>
+    </div>
+    <div class="form-control mt-10">
+      <%= f.label :meal_memo %>
+      <%= f.text_area :meal_memo, class: "input input-bordered" %>
+    </div>
+    <div class="form-control mt-6">
+      <%= f.submit class: "btn btn-primary"%>
+    </div>
+  <% end %>
+    <div class="btn btn-secondary flex justify-center">
+      <%= link_to (t 'meals.destroy.delete_a_meal'), meal_path(@meal), data: { turbo_method: :delete, turbo_confirm: '本当に削除しますか?' } %>
+    </div>
+  </div>
+</div>

--- a/app/views/meals/show.html.erb
+++ b/app/views/meals/show.html.erb
@@ -1,0 +1,10 @@
+<h1 class="text-5xl font-bold"><%= t '.title' %></h1>
+<h1 class="text-5xl font-bold"><%= @meal.meal_period_i18n %></h1>
+<h1 class="text-5xl font-bold"><%= @meal.meal_type_i18n %></h1>
+<h1 class="text-5xl font-bold"><%= @meal.meal_details.pluck(:meal_title) %></h1>
+<h1 class="text-5xl font-bold"><%= @meal.meal_details.pluck(:meal_calorie) %></h1>
+<h1 class="text-5xl font-bold"><%= @meal.meal_details.pluck(:meal_weight) %></h1>
+<h1 class="text-5xl font-bold">id <%= params[:id] %></h1>
+<button class="btn btn-active btn-primary">
+  <%= link_to (t '.to_edit_page'), edit_meal_path(@meal) %>
+</button>

--- a/config/locales/activerecord/ja.yml
+++ b/config/locales/activerecord/ja.yml
@@ -37,6 +37,18 @@ ja:
         meal_period: "食事タイミング"
         meal_type: "食事タイプ"
         meal_memo: "メモ"
+        meal_title_first: "メニューその1"
+        meal_weight_first: "量(g)"
+        meal_calorie_first: "カロリー"
+        meal_title_second: "メニューその2"
+        meal_weight_second: "量(g)"
+        meal_calorie_second: "カロリー"
+        meal_title_third: "メニューその3"
+        meal_weight_third: "量(g)"
+        meal_calorie_third: "カロリー"
+        meal_title: "献立名"
+        meal_weight: "量(g)"
+        meal_calorie: "カロリー"
   activemodel:
     attributes:
       workout_form:

--- a/config/locales/views/ja.yml
+++ b/config/locales/views/ja.yml
@@ -57,3 +57,12 @@ ja:
   meals:
     new:
       title: "食事新規投稿"
+    show:
+      title: "食事詳細"
+      to_edit_page: "編集"
+    edit:
+      title: "食事編集"
+      submit: "更新"
+    destroy:
+      success: "削除しました"
+      delete_a_meal: "削除する"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -7,5 +7,5 @@ Rails.application.routes.draw do
   resources :users, only: %i[show new create]
   resource :profile, only: %i[show edit update destroy]
   resources :workouts, only: %i[show new create edit update destroy]
-  resources :meals, only: %i[new create]
+  resources :meals, only: %i[show new create edit update destroy]
 end

--- a/spec/support/capybara.rb
+++ b/spec/support/capybara.rb
@@ -1,7 +1,7 @@
 RSpec.configure do |config|
-  config.before(:each, type: :system) do
-    driven_by :rack_test
-  end
+  # config.before(:each, type: :system) do
+  #   driven_by :rack_test
+  # end
 
   config.before(:each, js: true, type: :system) do
     driven_by :selenium_chrome

--- a/spec/support/capybara.rb
+++ b/spec/support/capybara.rb
@@ -1,7 +1,7 @@
 RSpec.configure do |config|
-  # config.before(:each, type: :system) do
-  #   driven_by :rack_test
-  # end
+  config.before(:each, type: :system) do
+    driven_by :rack_test
+  end
 
   config.before(:each, js: true, type: :system) do
     driven_by :selenium_chrome

--- a/spec/system/meals_spec.rb
+++ b/spec/system/meals_spec.rb
@@ -39,4 +39,55 @@ RSpec.describe 'Meals' do
     expect(page).to have_content '食事投稿を作成しました'
     expect(page).to have_current_path user_path(user), ignore_query: true
   end
+
+  it 'マイページの食事投稿をクリックすると食事詳細画面が表示されること' do
+    login_as(user)
+    visit user_path(user)
+    click_on '昼食'
+    expect(page).to have_content '食事詳細'
+    # current_pathのチェック追加
+  end
+
+  it '食事詳細画面の編集ボタンをクリックすると編集画面に遷移すること' do
+    login_as(user)
+    visit user_path(user)
+    click_on '昼食'
+    click_button '編集'
+    expect(page).to have_content '食事編集'
+    # current_pathのチェック追加
+  end
+
+  it '食事編集から項目を入力して更新をクリックすると更新できること' do
+    login_as(user)
+    visit user_path(user)
+    click_on '忠直'
+    click_button '編集'
+    select '昼食', from: '食事タイミング'
+    select '自炊', from: '食事タイプ'
+    fill_in 'メニューその1', with: 'お弁当'
+    fill_in 'meal_form_meal_weight_first', with: 200
+    fill_in 'meal_form_meal_calorie_first', with: 500
+    fill_in 'メニューその2', with: '味噌汁'
+    fill_in 'meal_form_meal_weight_second', with: 120
+    fill_in 'meal_form_meal_calorie_second', with: 100
+    fill_in 'メニューその3', with: 'ジュース'
+    fill_in 'meal_form_meal_weight_third', with: 100
+    fill_in 'meal_form_meal_calorie_third', with: 80
+    fill_in 'メモ', with: 'お弁当おいしい'
+    click_button '投稿する'
+    expect(page).to have_content '筋トレ投稿を更新しました'
+    expect(page).to have_current_path user_path(user), ignore_query: true
+  end
+
+  it '食事編集画面で削除をクリックすると削除できること' do
+    login_as(user)
+    visit user_path(user)
+    click_on '昼食'
+    click_button '編集'
+    page.accept_confirm do
+      click_on '削除する'
+    end
+    expect(page).to have_content '食事投稿を削除しました'
+    expect(page).to have_current_path user_path(user), ignore_query: true
+  end
 end

--- a/spec/system/meals_spec.rb
+++ b/spec/system/meals_spec.rb
@@ -1,12 +1,12 @@
 require 'rails_helper'
 
-RSpec.describe 'Meals' do
+RSpec.describe 'Meals', js: true do
   let(:user) { create(:user) }
 
   before do
     MealForm.new(
-      meal_period: 'breakfast',
-      meal_type: 'self_catering',
+      meal_period: 1,
+      meal_type: 1,
       meal_title_first: '唐揚げ',
       meal_weight_first: 200,
       meal_calorie_first: 500,
@@ -60,22 +60,22 @@ RSpec.describe 'Meals' do
   it '食事編集から項目を入力して更新をクリックすると更新できること' do
     login_as(user)
     visit user_path(user)
-    click_on '忠直'
+    click_on '昼食'
     click_button '編集'
     select '昼食', from: '食事タイミング'
     select '自炊', from: '食事タイプ'
     fill_in 'メニューその1', with: 'お弁当'
-    fill_in 'meal_form_meal_weight_first', with: 200
-    fill_in 'meal_form_meal_calorie_first', with: 500
+    fill_in 'meal_meal_weight_first', with: 200
+    fill_in 'meal_meal_calorie_first', with: 500
     fill_in 'メニューその2', with: '味噌汁'
-    fill_in 'meal_form_meal_weight_second', with: 120
-    fill_in 'meal_form_meal_calorie_second', with: 100
+    fill_in 'meal_meal_weight_second', with: 120
+    fill_in 'meal_meal_calorie_second', with: 100
     fill_in 'メニューその3', with: 'ジュース'
-    fill_in 'meal_form_meal_weight_third', with: 100
-    fill_in 'meal_form_meal_calorie_third', with: 80
+    fill_in 'meal_meal_weight_third', with: 100
+    fill_in 'meal_meal_calorie_third', with: 80
     fill_in 'メモ', with: 'お弁当おいしい'
-    click_button '投稿する'
-    expect(page).to have_content '筋トレ投稿を更新しました'
+    click_button '更新する'
+    expect(page).to have_content '食事投稿を更新しました'
     expect(page).to have_current_path user_path(user), ignore_query: true
   end
 


### PR DESCRIPTION
## 概要
食事投稿機能のshow, edit, update, destroyアクションを実装しました。

## 確認方法

1. 筋トレ投稿同様、マイページの食事タイミング("昼食"など)をクリックするとshow画面に遷移することを確認
2. show画面より「編集」ボタンクリックでedit画面へ遷移することを確認
3. 内容変更し「更新」ボタンクリックで更新、エラーの場合はフラッシュメッセージで再度edit画面をレンダリング
4. edit画面中の「削除」ボタンクリックにより投稿を削除できることを確認

## チェックリスト
- [x] Lint のチェックをパスした
- [x] システムテストをパスした

## コメント
今後、更新失敗時のテストを記述すること。
close #75 