### PR TITLE
[heroku_debug#85] Herokuデプロイ時のデバッグ

### DIFF
--- a/app/models/type_array.rb
+++ b/app/models/type_array.rb
@@ -1,5 +1,0 @@
-# class TypeArray < ActiveModel::Type::Value
-#   def cast_value(value)
-#     value
-#   end
-# end

--- a/config/initializers/types.rb
+++ b/config/initializers/types.rb
@@ -1,7 +1,0 @@
-# class TypeArray < ActiveModel::Type::Value
-#   def cast_value(value)
-#     value
-#   end
-# end
-
-# ActiveModel::Type.register(:array, TypeArray)


### PR DESCRIPTION
## 概要
- `app/models/type_array.rb`と`config/initializers/types.rb`を削除
- Zeitwerkでファイルパスを自動で判断して、Arrayクラスを探してしまっていた模様

## 確認方法
- 本番環境で正常にアプリが起動することを確認

## 影響範囲
- workout_formオブジェクトのbody_part_idsおよびworkout_images
- 型を定義しない実装に修正したため、今後不具合が起きた場合にはArray型を定義する。

## チェックリスト

- [x] Lint のチェックをパスした
- [x] テストをパスした

## コメント
- `ActiveModel::Attributes`に独自の型（Array型）を定義しない方針に
- 不具合があれば対応
close #85 