### PR TITLE
[Add images to meals#87] 食事投稿機能への写真アップロード機能 

### DIFF
--- a/app/controllers/meals_controller.rb
+++ b/app/controllers/meals_controller.rb
@@ -88,14 +88,16 @@ class MealsController < ApplicationController
     params.require(:meal_form).permit(:meal_period, :meal_type, :meal_memo,
                                       :meal_title_first, :meal_weight_first, :meal_calorie_first,
                                       :meal_title_second, :meal_weight_second, :meal_calorie_second,
-                                      :meal_title_third, :meal_weight_third, :meal_calorie_third).merge(user_id: current_user.id)
+                                      :meal_title_third, :meal_weight_third, :meal_calorie_third,
+                                      meal_images: []).merge(user_id: current_user.id)
   end
 
   def meal_params
     params.require(:meal).permit(:meal_period, :meal_type, :meal_memo,
                                  :meal_title_first, :meal_weight_first, :meal_calorie_first,
                                  :meal_title_second, :meal_weight_second, :meal_calorie_second,
-                                 :meal_title_third, :meal_weight_third, :meal_calorie_third).merge(user_id: current_user.id, meal_id: params[:id])
+                                 :meal_title_third, :meal_weight_third, :meal_calorie_third,
+                                 meal_images: []).merge(user_id: current_user.id, meal_id: params[:id])
   end
 
   def set_user

--- a/app/forms/meal_form.rb
+++ b/app/forms/meal_form.rb
@@ -16,8 +16,8 @@ class MealForm
   attribute :meal_title_third, :string
   attribute :meal_weight_third, :integer
   attribute :meal_calorie_third, :integer
-
   attribute :meal_id, :big_integer
+  attribute :meal_images
 
   validates :meal_title_first, presence: true
   validates :meal_weight_first, presence: true
@@ -26,7 +26,7 @@ class MealForm
   def save
     return false if invalid?
 
-    meal = Meal.create(meal_period:, meal_type:, meal_memo:, user_id:)
+    meal = Meal.create(meal_period:, meal_type:, meal_memo:, meal_images:, user_id:)
     meal.meal_details.build(meal_title: meal_title_first, meal_weight: meal_weight_first, meal_calorie: meal_calorie_first).save
     if meal_title_second.present?
       meal.meal_details.build(meal_title: meal_title_second, meal_weight: meal_weight_second,
@@ -43,7 +43,7 @@ class MealForm
     return false if invalid?
 
     meal = Meal.find(meal_id)
-    meal.update!(meal_period:, meal_type:, meal_memo:, user_id:)
+    meal.update!(meal_period:, meal_type:, meal_memo:, meal_images:, user_id:)
     MealDetail.where(meal_id: meal.id).delete_all
     meal.meal_details.build(meal_title: meal_title_first, meal_weight: meal_weight_first, meal_calorie: meal_calorie_first).save
     if meal_title_second.present?

--- a/app/models/meal.rb
+++ b/app/models/meal.rb
@@ -2,6 +2,10 @@ class Meal < ApplicationRecord
   belongs_to :user
   has_many :meal_details, dependent: :destroy
 
+  has_many_attached :meal_images do |attachable|
+    attachable.variant :thumb, resize_to_limit: [200, 200]
+  end
+
   enum meal_period: { breakfast: 0, lunch: 1, dinner: 2, nosh: 3 }
   enum meal_type: { self_catering: 0, eating_out: 1, to_go: 2, convenience_store: 3 }
 end

--- a/app/views/meals/_meal.html.erb
+++ b/app/views/meals/_meal.html.erb
@@ -6,6 +6,9 @@
       </h4>
       <h4><%= meal.meal_details.pluck(:meal_title).join(',')%></h4>
       <p><%= meal.meal_details.pluck(:meal_calorie).sum %>kcal</p>
+      <div>
+        <%= image_tag meal.meal_images.last.variant(:thumb) if meal.meal_images.attached? %>
+      </div>
     </div>
   </div>
 </div>

--- a/app/views/meals/edit.html.erb
+++ b/app/views/meals/edit.html.erb
@@ -58,6 +58,10 @@
       <%= f.label :meal_memo %>
       <%= f.text_area :meal_memo, class: "input input-bordered" %>
     </div>
+    <div class="form-control mt-10">
+      <%= f.label :meal_images %>
+      <%= f.file_field :meal_images, class: "input input-bordered", multiple: true %>
+    </div>
     <div class="form-control mt-6">
       <%= f.submit class: "btn btn-primary"%>
     </div>

--- a/app/views/meals/new.html.erb
+++ b/app/views/meals/new.html.erb
@@ -63,6 +63,10 @@
         <%= f.label :meal_memo %>
         <%= f.text_area :meal_memo, class: "input input-bordered" %>
       </div>
+      <div class="form-control mt-10">
+        <%= f.label :meal_images %>
+        <%= f.file_field :meal_images, class: "input input-bordered", multiple: true %>
+      </div>
       <div class="form-control mt-6">
         <%= f.submit '投稿する', class: "btn btn-primary"%>
       </div>

--- a/app/views/meals/show.html.erb
+++ b/app/views/meals/show.html.erb
@@ -5,6 +5,14 @@
 <h1 class="text-5xl font-bold"><%= @meal.meal_details.pluck(:meal_calorie) %></h1>
 <h1 class="text-5xl font-bold"><%= @meal.meal_details.pluck(:meal_weight) %></h1>
 <h1 class="text-5xl font-bold">id <%= params[:id] %></h1>
+<% if @meal.meal_images.attached? %>
+  <% @meal.meal_images.each do |meal_image|%>
+  <div class="px-8">
+    <h2 class="text-xl py-6 font-bold">食事画像</h2>
+    <%= image_tag meal_image.variant(:thumb) if meal_image.representable? %>
+  </div>
+  <% end %>
+<% end %>
 <button class="btn btn-active btn-primary">
   <%= link_to (t '.to_edit_page'), edit_meal_path(@meal) %>
 </button>

--- a/spec/system/meals_spec.rb
+++ b/spec/system/meals_spec.rb
@@ -35,8 +35,10 @@ RSpec.describe 'Meals', js: true do
     fill_in 'meal_form_meal_weight_third', with: 200
     fill_in 'meal_form_meal_calorie_third', with: 500
     fill_in 'メモ', with: '唐揚げおいしい'
+    attach_file 'meal_form[meal_images][]', "#{Rails.root}/spec/fixtures/images/sample_man.png"
     click_button '投稿する'
     expect(page).to have_content '食事投稿を作成しました'
+    expect(page).to have_selector("img[src$='sample_man.png']")
     expect(page).to have_current_path user_path(user), ignore_query: true
   end
 
@@ -74,8 +76,10 @@ RSpec.describe 'Meals', js: true do
     fill_in 'meal_meal_weight_third', with: 100
     fill_in 'meal_meal_calorie_third', with: 80
     fill_in 'メモ', with: 'お弁当おいしい'
+    attach_file 'meal[meal_images][]', "#{Rails.root}/spec/fixtures/images/sample.png"
     click_button '更新する'
     expect(page).to have_content '食事投稿を更新しました'
+    expect(page).to have_selector("img[src$='sample.png']")
     expect(page).to have_current_path user_path(user), ignore_query: true
   end
 


### PR DESCRIPTION
## 概要
- Active Storageを用いて食事投稿への写真アップロード機能を追加

## 確認方法
- 食事新規投稿および編集画面から写真を複数枚投稿できることを確認


## 影響範囲
mealモデル、meal_formオブジェクト

## チェックリスト
- [x] Lint のチェックをパスした
- [ ] テストをパスした

## コメント
- ビューファイルは後日修正
close #87 