### PR TITLE
[Fix] ヘッダーのレスポンシブ対応 #89

### DIFF
--- a/app/views/shared/_before_login_header.html.erb
+++ b/app/views/shared/_before_login_header.html.erb
@@ -5,18 +5,18 @@
 
   <div class="hidden md:flex md:justify-end">
     <ul class="menu menu-horizontal px-1">
-      <li><%= link_to (t 'defaults.signup'), new_user_path %></li>
-      <li><%= link_to (t 'defaults.login'), login_path %></li>
+      <li><%= link_to (t 'user_sessions.new.to_register_page'), new_user_path %></li>
+      <li><%= link_to (t 'users.new.to_login_page'), login_path %></li>
     </ul>
   </div>
 
   <div class="btm-nav md:hidden">
     <ul class="menu menu-horizontal px-1">
       <li class="px-4">
-        <button class="btn"><%= link_to (t 'defaults.signup'), new_user_path %></button>
+        <button class="btn"><%= link_to (t 'user_sessions.new.to_register_page'), new_user_path %></button>
       </li>
       <li class="px-4">
-        <button class="btn btn-primary"><%= link_to (t 'defaults.login'), login_path %></button>
+        <button class="btn btn-primary"><%= link_to (t 'users.new.to_login_page'), login_path %></button>
       </li>
     </ul>
   </div>

--- a/app/views/shared/_before_login_header.html.erb
+++ b/app/views/shared/_before_login_header.html.erb
@@ -1,14 +1,24 @@
-<header>
-  <div class="navbar bg-primary">
-    <div class="flex-1">
-      <a class="btn btn-ghost normal-case text-xl">トレミル</a>
-    </div>
-    <div class="flex-none">
-      <ul class="menu menu-horizontal p-0">
-        <li><%= link_to (t 'defaults.about'), "#" %></li>
-        <li><%= link_to (t 'defaults.signup'), new_user_path %></li>
-        <li><%= link_to (t 'defaults.login'), login_path %></li>
-      </ul>
-    </div>
+<header class="navbar bg-primary text-primary-content flex justify-between">
+  <div class="flex-1">
+    <%= link_to (t 'defaults.top'), root_path, class: "btn btn-ghost normal-case text-xl" %>
   </div>
+
+  <div class="hidden md:flex md:justify-end">
+    <ul class="menu menu-horizontal px-1">
+      <li><%= link_to (t 'defaults.signup'), new_user_path %></li>
+      <li><%= link_to (t 'defaults.login'), login_path %></li>
+    </ul>
+  </div>
+
+  <div class="btm-nav md:hidden">
+    <ul class="menu menu-horizontal px-1">
+      <li class="px-4">
+        <button class="btn"><%= link_to (t 'defaults.signup'), new_user_path %></button>
+      </li>
+      <li class="px-4">
+        <button class="btn btn-primary"><%= link_to (t 'defaults.login'), login_path %></button>
+      </li>
+    </ul>
+  </div>
+
 </header>

--- a/app/views/shared/_header.html.erb
+++ b/app/views/shared/_header.html.erb
@@ -1,24 +1,21 @@
-<header>
-  <div class="navbar bg-primary">
-    <div class="flex-1">
-      <a class="btn btn-ghost normal-case text-xl">トレミル</a>
+<header class="navbar bg-primary text-primary-content flex justify-between">
+  <div class="flex-1">
+    <%= link_to (t 'defaults.top'), root_path, class: "btn btn-ghost normal-case text-xl" %>
+  </div>
+  <div class="flex-none gap-2">
+    <div class="form-control">
+      <input type="text" placeholder="Sorry, Coming soon...." class="input input-bordered" />
     </div>
-    <div class="flex-none gap-2">
-      <div class="form-control">
-        <input type="text" placeholder="Search" class="input input-bordered" />
-      </div>
-      <div class="dropdown dropdown-end">
-        <label tabindex="0" class="btn btn-ghost btn-circle avatar" id="header-avatar">
-          <div class="w-10 rounded-full">
-            <%= image_tag @user.avatar.variant(:thumb) if @user.avatar.attached? %>
-          </div>
-        </label>
-        <ul tabindex="0" class="mt-3 p-2 shadow menu menu-compact dropdown-content bg-base-100 rounded-box w-52">
-          <li><%= link_to (t 'defaults.profile'), profile_path %></li>
-          <li><a>Settings</a></li>
-          <li><%= link_to (t 'defaults.logout'), logout_path, data: { turbo_method: :delete } %></li>
-        </ul>
-      </div>
+    <div class="dropdown dropdown-end">
+      <label tabindex="0" class="btn btn-ghost btn-circle avatar" id="header-avatar">
+        <div class="w-10 rounded-full">
+          <%= image_tag @user.avatar.variant(:thumb) if @user.avatar.attached? %>
+        </div>
+      </label>
+      <ul tabindex="0" class="mt-3 p-2 shadow menu menu-compact dropdown-content bg-base-100 rounded-box w-52 text-base-content">
+        <li><%= link_to (t 'defaults.profile'), profile_path %></li>
+        <li><%= link_to (t 'defaults.logout'), logout_path, data: { turbo_method: :delete } %></li>
+      </ul>
     </div>
   </div>
 </header>

--- a/app/views/static_pages/top.html.erb
+++ b/app/views/static_pages/top.html.erb
@@ -3,7 +3,7 @@
     <div class="max-w-md">
       <h1 class="text-5xl font-bold">Training&Meals</h1>
       <p class="py-6">トレミルはあなたのバルキーな体作りをサポートします</p>
-      <%= link_to '新規登録', new_user_path, class: 'btn btn-primary'%>
+      <%= link_to 'ユーザーの投稿をチェック（会員登録不要）', '#', class: 'btn'%>
     </div>
   </div>
 </div>

--- a/config/locales/views/ja.yml
+++ b/config/locales/views/ja.yml
@@ -1,10 +1,10 @@
 ja:
   defaults:
+    top: "トレミル"
     signup: "新規登録"
     login: "ログイン"
     register: "登録"
     logout: "ログアウト"
-    about: "このアプリについて"
     calorie_search: "カロリー検索したいメニューを入力してください"
     message:
       require_login: "ログインしてください"

--- a/spec/support/login_support.rb
+++ b/spec/support/login_support.rb
@@ -1,7 +1,6 @@
 module LoginSupport
   def login_as(user)
-    visit root_path
-    click_link 'ログイン'
+    visit login_path
     fill_in 'メールアドレス', with: user.email
     fill_in 'パスワード', with: 'password'
     click_button 'ログイン'


### PR DESCRIPTION
## 概要
- スマホサイズの場合にヘッダーはロゴのみ、ページ下部にボトムメニューで`新規登録ページへ`と`ログインページへ`ボタンを固定する
- タブレットサイズ以上の場合、ロゴ =>（左）、新規登録、ログイン => （右）をヘッダーに並べて表示する
- ヘッダーのロゴをクリックするとトップページに遷移する
- トップページにはアプリの説明(about)を表示する

変更前
![変更前](https://user-images.githubusercontent.com/26403599/210242577-546b94c6-e3fc-4865-878a-6cfd35418426.png)

変更後
![変更後](https://user-images.githubusercontent.com/26403599/210245362-28301267-83f2-48ba-8e8a-3857430c442e.png)


## 確認方法
ログイン前のトップページで概要の内容を満たしているか確認（aboutの内容は今後追加）

## 影響範囲
ログイン前のUI全体に影響


## チェックリスト
- [x] Lint のチェックをパスした
- [x] テストをパスした

## コメント
aboutの内容は今後追加。ログイン後、サイドバーのレスポンシブを今後対応。
close #89 