### PR TITLE
[Change sidebar UI#91] サイドバーのレスポンシブ対応

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -11,19 +11,17 @@
     <%= javascript_include_tag "application", "data-turbo-track": "reload", defer: true %>
   </head>
 
-  <body>
+  <body class="min-h-screen">
     <% if logged_in? %>
       <%= render 'shared/header' %>
     <% else %>
       <%= render 'shared/before_login_header' %>
     <% end %>
-    <%= render 'shared/flash_message' %>
+      <%= render 'shared/flash_message' %>
     <% if logged_in? %>
-      <div class="container mx-auto flex justify-between w-full">
-        <div class="container mx-auto w-1/6">
-          <%= render 'shared/sidebar' %>
-        </div>
-        <div class="container mx-auto w-5/6">
+      <div class="main-wrapper flex">
+        <%= render 'shared/sidebar' %>
+        <div class="main-content container mx-auto">
           <%= yield %>
         </div>
       </div>

--- a/app/views/shared/_before_login_header.html.erb
+++ b/app/views/shared/_before_login_header.html.erb
@@ -10,7 +10,7 @@
     </ul>
   </div>
 
-  <div class="btm-nav md:hidden">
+  <div class="btm-nav md:hidden fixed">
     <ul class="menu menu-horizontal px-1">
       <li class="px-4">
         <button class="btn"><%= link_to (t 'user_sessions.new.to_register_page'), new_user_path %></button>

--- a/app/views/shared/_sidebar.html.erb
+++ b/app/views/shared/_sidebar.html.erb
@@ -1,31 +1,58 @@
-<div class="flex flex-wrap w-full justify-center border-r-8 border-primary-content">
-  <ul class="menu bg-base-100">
-    <li><%= link_to 'マイページ', user_path(@user.id) %><li>
-    <li><%= link_to 'タイムライン', home_workouts_path %></li>
-    <li><%= link_to 'お気に入り', '#' %></li>
-  </ul>
-
-  <div class="dropdown dropdown-right my-8">
-    <label tabindex="0" class="btn btn-ghost">新規投稿作成</label>
-    <ul tabindex="0" class="dropdown-content menu p-2 shadow bg-base-100 rounded-box w-52">
-      <li><%= link_to '筋トレ投稿作成', new_workout_path %></li>
-      <li><%= link_to '食事投稿作成', new_meal_path %></li>
+<div class="sidebar hidden md:flex md:flex-col md:min-w-max md:p-4 md:bg-base-300">
+  <nav class="text-center">
+    <ul class="menu">
+      <li><%= link_to 'マイページ', user_path(@user.id) %><li>
+      <li><%= link_to 'タイムライン', home_workouts_path %></li>
     </ul>
-  </div>
-
-  <div>
-    <ul class="menu bg-base-100">
-      <li><%= link_to '下書き一覧', '#' %></li>
-    </ul>
-  </div>
-
-  <div class="avatar my-8">
-    <div class="w-24 rounded-full ring ring-primary ring-offset-base-100 ring-offset-2">
-      <%= image_tag @user.avatar.variant(:thumb) if @user.avatar.attached? %>
+    <div class="menu dropdown dropdown-right my-4">
+      <label tabindex="0">新規投稿作成</label>
+      <ul tabindex="0" class="dropdown-content menu p-2 shadow bg-base-100 rounded-box w-52">
+        <li><%= link_to '筋トレ', new_workout_path %></li>
+        <li><%= link_to '食事', new_meal_path %></li>
+      </ul>
+    </div>
+  </nav>
+  <div class="side-profile text-center my-8 w-36">
+    <div class="avatar">
+      <div class="w-24 rounded-full ring ring-primary ring-offset-base-100 ring-offset-2">
+        <%= image_tag @user.avatar.variant(:thumb) if @user.avatar.attached? %>
+      </div>
+    </div>
+    <div class="user-info">
+      <h2 class="mt-4 font-bold text-lg">ユーザー名</h2>
+      <p><%= @user.name %><p>
+      <h2 class="mt-4 font-bold text-lg ">自己紹介</h2>
+      <p class="text-left"><%= @user.introduction %><p>
     </div>
   </div>
-
-  <ul class="menu bg-base-100 my-8">
-    <li><%= link_to 'フォロー/フォロワー', '#' %><li>
-  </ul>
 </div>
+
+<div class="btm-nav z-50 md:hidden bg-base-300">
+  <%= link_to user_path(@user.id) do %>
+    <button>
+      <svg xmlns="http://www.w3.org/2000/svg" class="h-5 w-5" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M3 12l2-2m0 0l7-7 7 7M5 10v10a1 1 0 001 1h3m10-11l2 2m-2-2v10a1 1 0 01-1 1h-3m-6 0a1 1 0 001-1v-4a1 1 0 011-1h2a1 1 0 011 1v4a1 1 0 001 1m-6 0h6" /></svg>
+      <span class="btm-nav-label">マイページ</span>
+    </button>
+  <% end %>
+  <%= link_to home_workouts_path do %>
+    <button>
+      <svg xmlns="http://www.w3.org/2000/svg" class="h-5 w-5" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor">
+      <path stroke-linecap="round" stroke-linejoin="round" d="M6 6.878V6a2.25 2.25 0 012.25-2.25h7.5A2.25 2.25 0 0118 6v.878m-12 0c.235-.083.487-.128.75-.128h10.5c.263 0 .515.045.75.128m-12 0A2.25 2.25 0 004.5 9v.878m13.5-3A2.25 2.25 0 0119.5 9v.878m0 0a2.246 2.246 0 00-.75-.128H5.25c-.263 0-.515.045-.75.128m15 0A2.25 2.25 0 0121 12v6a2.25 2.25 0 01-2.25 2.25H5.25A2.25 2.25 0 013 18v-6c0-.98.626-1.813 1.5-2.122" />
+      </svg>
+      <span class="btm-nav-label">タイムライン</span>
+    </button>
+  <% end %>
+  <button>
+    <div class="dropdown dropdown-top dropdown-end">
+      <svg xmlns="http://www.w3.org/2000/svg" class="h-5 w-5" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" tabindex="0">
+      <path stroke-linecap="round" stroke-linejoin="round" d="M16.862 4.487l1.687-1.688a1.875 1.875 0 112.652 2.652L10.582 16.07a4.5 4.5 0 01-1.897 1.13L6 18l.8-2.685a4.5 4.5 0 011.13-1.897l8.932-8.931zm0 0L19.5 7.125M18 14v4.75A2.25 2.25 0 0115.75 21H5.25A2.25 2.25 0 013 18.75V8.25A2.25 2.25 0 015.25 6H10" />
+      </svg>
+      <span tabindex="0" class="btm-nav-label">新規投稿作成</span>
+        <ul tabindex="0" class="dropdown-content menu p-2 shadow bg-base-100 rounded-box w-52">
+          <li><%= link_to '筋トレ', new_workout_path %></li>
+          <li><%= link_to '食事', new_meal_path %></li>
+        </ul>
+    </div>
+  </button>
+</div>
+

--- a/spec/system/user_sessions_spec.rb
+++ b/spec/system/user_sessions_spec.rb
@@ -50,24 +50,6 @@ RSpec.describe 'UserSessions' do
         visit profile_path
         expect(page).to have_link 'タイムライン'
       end
-
-      it 'ログイン後サイドバーが表示され、お気に入りのリンクがあること' do
-        login_as(user)
-        visit profile_path
-        expect(page).to have_link 'お気に入り'
-      end
-
-      it 'ログイン後サイドバーが表示され、下書き一覧のリンクがあること' do
-        login_as(user)
-        visit profile_path
-        expect(page).to have_link '下書き一覧'
-      end
-
-      it 'ログイン後サイドバーが表示され、フォロー/フォロワーのリンクがあること' do
-        login_as(user)
-        visit profile_path
-        expect(page).to have_link 'フォロー/フォロワー'
-      end
     end
   end
 end


### PR DESCRIPTION
## 概要
- スマホサイズの場合にボトムメニューにする
- タブレットサイズ以上の場合、サイドメニュー表示にする

変更前
<img width="519" alt="変更前" src="https://user-images.githubusercontent.com/26403599/210344070-c61a3f03-ffe9-41e3-9afb-806d310b3e26.png">

変更後
<img width="523" alt="変更後" src="https://user-images.githubusercontent.com/26403599/210344093-cfe6149f-a935-481f-b589-79accc067d18.png">


## 確認方法
ログイン後のサイドメニューが`概要`のとおりとなっているか確認


## 影響範囲
ログイン後のビュー全てに影響

## チェックリスト
- [x] Lint のチェックをパスした
- [x] テストをパスした


## コメント
- ボトムメニューのsvgアイコンの中央寄せを今後対応
- サイドバーの見た目がなんだかカッコよくないので最後に修正
close #91 