### PR TITLE
[Fix user authorization#93] ユーザーの認可設定

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,9 +1,17 @@
 class ApplicationController < ActionController::Base
   add_flash_types :success, :info, :warning, :danger
   before_action :require_login
+  before_action :set_user
 
+  # ログイン済みユーザーかどうか確認(:require_loginのメソッドに追加)
   def not_authenticated
     flash[:warning] = t('defaults.message.require_login')
     redirect_to login_path
+  end
+
+  private
+
+  def set_user
+    @user = User.find(current_user.id) if logged_in?
   end
 end

--- a/app/controllers/home_controller.rb
+++ b/app/controllers/home_controller.rb
@@ -1,5 +1,5 @@
 class HomeController < ApplicationController
-  before_action :set_user, only: %i[workouts meals]
+  skip_before_action :require_login
 
   def workouts
     @workouts = Workout.includes(:user).order(created_at: :desc)
@@ -7,9 +7,5 @@ class HomeController < ApplicationController
 
   def meals
     @meals = Meal.includes(:user, :meal_details).order(created_at: :desc)
-  end
-
-  def set_user
-    @user = User.find(current_user.id)
   end
 end

--- a/app/controllers/static_pages_controller.rb
+++ b/app/controllers/static_pages_controller.rb
@@ -1,12 +1,6 @@
 class StaticPagesController < ApplicationController
   skip_before_action :require_login
-  before_action :set_user
 
   def top; end
 
-  private
-
-  def set_user
-    @user = User.find(current_user.id) if logged_in?
-  end
 end

--- a/app/controllers/static_pages_controller.rb
+++ b/app/controllers/static_pages_controller.rb
@@ -2,5 +2,4 @@ class StaticPagesController < ApplicationController
   skip_before_action :require_login
 
   def top; end
-
 end

--- a/app/controllers/workouts_controller.rb
+++ b/app/controllers/workouts_controller.rb
@@ -1,15 +1,17 @@
 class WorkoutsController < ApplicationController
-  before_action :set_user, only: %i[new show create edit update destroy]
-  before_action :set_workout, only: %i[show edit destroy]
+  skip_before_action :require_login, only: %i[show]
 
-  def show; end
+  def show
+    @workout = Workout.find(params[:id])
+  end
 
   def new
-    @workout_form = WorkoutForm.new(@workout)
+    @workout_form = WorkoutForm.new
   end
 
   def edit
-    @workout_form = Workout.find(params[:id])
+    @workout_form = current_user.workouts.find_by(id: params[:id])
+    redirect_to root_url, status: :see_other if @workout_form.nil?
   end
 
   def create
@@ -33,6 +35,8 @@ class WorkoutsController < ApplicationController
   end
 
   def destroy
+    @workout = current_user.workouts.find_by(id: params[:id])
+    redirect_to root_url, status: :see_other if @workout.nil?
     @workout.destroy!
     redirect_to user_path(@user.id), success: t('defaults.message.deleted', item: Workout.model_name.human)
   end
@@ -49,13 +53,5 @@ class WorkoutsController < ApplicationController
     params.require(:workout).permit(:workout_date, :workout_title, :workout_time,
                                     :workout_weight, :repetition_count,
                                     :set_count, :workout_memo, body_part_ids: [], workout_images: []).merge(user_id: current_user.id, workout_id: params[:id])
-  end
-
-  def set_user
-    @user = User.find(current_user.id)
-  end
-
-  def set_workout
-    @workout = Workout.find(params[:id])
   end
 end

--- a/app/forms/workout_form.rb
+++ b/app/forms/workout_form.rb
@@ -32,7 +32,7 @@ class WorkoutForm
     end
   end
 
-  def update 
+  def update
     return false if invalid?
 
     workout = Workout.find(workout_id)

--- a/app/forms/workout_form.rb
+++ b/app/forms/workout_form.rb
@@ -32,7 +32,7 @@ class WorkoutForm
     end
   end
 
-  def update
+  def update 
     return false if invalid?
 
     workout = Workout.find(workout_id)

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -23,4 +23,8 @@ class User < ApplicationRecord
 
   enum sex: { male: 0, female: 1 }
   enum active_level: { level1: 1, level2: 2, level3: 3, level4: 4, level5: 5 }
+
+  def own?(object)
+    object.user_id == id
+  end
 end

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -14,11 +14,7 @@
   <body class="min-h-screen">
     <% if logged_in? %>
       <%= render 'shared/header' %>
-    <% else %>
-      <%= render 'shared/before_login_header' %>
-    <% end %>
       <%= render 'shared/flash_message' %>
-    <% if logged_in? %>
       <div class="main-wrapper flex">
         <%= render 'shared/sidebar' %>
         <div class="main-content container mx-auto">
@@ -26,6 +22,8 @@
         </div>
       </div>
     <% else %>
+      <%= render 'shared/before_login_header' %>
+      <%= render 'shared/flash_message' %>
       <%= yield %>
     <% end %>
     <%= render 'shared/footer' %>

--- a/app/views/meals/show.html.erb
+++ b/app/views/meals/show.html.erb
@@ -1,4 +1,5 @@
 <h1 class="text-5xl font-bold"><%= t '.title' %></h1>
+<h1 class="text-5xl font-bold text-red-600"><%= User.find(@meal.user_id).name %></h1>
 <h1 class="text-5xl font-bold"><%= @meal.meal_period_i18n %></h1>
 <h1 class="text-5xl font-bold"><%= @meal.meal_type_i18n %></h1>
 <h1 class="text-5xl font-bold"><%= @meal.meal_details.pluck(:meal_title) %></h1>
@@ -13,6 +14,8 @@
   </div>
   <% end %>
 <% end %>
-<button class="btn btn-active btn-primary">
-  <%= link_to (t '.to_edit_page'), edit_meal_path(@meal) %>
-</button>
+<% if logged_in? && current_user.own?(@meal)%>
+  <button class="btn btn-active btn-primary">
+    <%= link_to (t '.to_edit_page'), edit_meal_path(@meal) %>
+  </button>
+<% end %>

--- a/app/views/static_pages/top.html.erb
+++ b/app/views/static_pages/top.html.erb
@@ -3,7 +3,7 @@
     <div class="max-w-md">
       <h1 class="text-5xl font-bold">Training&Meals</h1>
       <p class="py-6">トレミルはあなたのバルキーな体作りをサポートします</p>
-      <%= link_to 'ユーザーの投稿をチェック（会員登録不要）', '#', class: 'btn'%>
+      <%= link_to 'ユーザーの投稿をチェック（会員登録不要）', home_workouts_path, class: 'btn'%>
     </div>
   </div>
 </div>

--- a/app/views/workouts/edit.html.erb
+++ b/app/views/workouts/edit.html.erb
@@ -45,7 +45,7 @@
     </div>
     <% end %>
     <div class="btn btn-secondary flex justify-center">
-      <%= link_to (t 'workouts.destroy.delete_a_workout'), workout_path(@workout), data: { turbo_method: :delete, turbo_confirm: '本当に削除しますか?' } %>
+      <%= link_to (t 'workouts.destroy.delete_a_workout'), workout_path(params[:id]), data: { turbo_method: :delete, turbo_confirm: '本当に削除しますか?' } %>
     </div>
   </div>
 </div>

--- a/app/views/workouts/show.html.erb
+++ b/app/views/workouts/show.html.erb
@@ -1,4 +1,5 @@
 <h1 class="text-5xl font-bold"><%= t '.title' %></h1>
+<h1 class="text-5xl font-bold text-red-600"><%= User.find(@workout.user_id).name %></h1>
 <h1 class="text-5xl font-bold"><%= @workout.workout_date.strftime("%Y年%m月%d日") %></h1>
 <h1 class="text-5xl font-bold"><%= @workout.workout_title %></h1>
 <h1 class="text-5xl font-bold"><%= @workout.body_parts.pluck(:body_part_name) %></h1>
@@ -11,6 +12,9 @@
   </div>
   <% end %>
 <% end %>
-<button class="btn btn-active btn-primary">
-  <%= link_to (t '.to_edit_page'), edit_workout_path(@workout) %>
-</button>
+<% if logged_in? && current_user.own?(@workout) %>
+  <button class="btn btn-active btn-primary">
+    <%= link_to (t '.to_edit_page'), edit_workout_path(@workout) %>
+  </button>
+<% end %>
+

--- a/spec/system/home_spec.rb
+++ b/spec/system/home_spec.rb
@@ -3,6 +3,16 @@ require 'rails_helper'
 RSpec.describe 'Home', js: true do
   let(:user) { create(:user) }
 
+  it '未ログインでも筋トレのタイムラインを閲覧できること' do
+    visit home_workouts_path
+    expect(page).to have_content 'タイムライン -筋トレ-'
+  end
+
+  it '未ログインでも食事のタイムラインを閲覧できること' do
+    visit home_meals_path
+    expect(page).to have_content 'タイムライン -食事-'
+  end
+
   it 'サイドバーのタイムラインをクリックすると筋トレのタイムラインが表示されること' do
     login_as(user)
     click_on 'タイムライン'

--- a/spec/system/meals_spec.rb
+++ b/spec/system/meals_spec.rb
@@ -95,7 +95,7 @@ RSpec.describe 'Meals', js: true do
     expect(page).to have_current_path user_path(user), ignore_query: true
   end
 
-  it '他人の投稿を編集できないこと' do #コントローラーレベルのテスト(認可外でedit/:id => root_pathへリダイレクトもテストしたい)
+  it '他人の投稿を編集できないこと' do # コントローラーレベルのテスト(認可外でedit/:id => root_pathへリダイレクトもテストしたい)
     another_user = create(:user)
     login_as(another_user)
     visit home_meals_path

--- a/spec/system/meals_spec.rb
+++ b/spec/system/meals_spec.rb
@@ -94,4 +94,19 @@ RSpec.describe 'Meals', js: true do
     expect(page).to have_content '食事投稿を削除しました'
     expect(page).to have_current_path user_path(user), ignore_query: true
   end
+
+  it '他人の投稿を編集できないこと' do #コントローラーレベルのテスト(認可外でedit/:id => root_pathへリダイレクトもテストしたい)
+    another_user = create(:user)
+    login_as(another_user)
+    visit home_meals_path
+    click_on '昼食'
+    expect(page).not_to have_content '編集'
+  end
+
+  it '未ログインでも投稿の詳細表示できること' do
+    visit home_meals_path
+    click_on '昼食'
+    expect(page).to have_content '食事詳細'
+    # current_pathのチェック追加
+  end
 end

--- a/spec/system/profiles_spec.rb
+++ b/spec/system/profiles_spec.rb
@@ -41,4 +41,10 @@ RSpec.describe 'Profiles', js: true do
     expect(page).to have_selector("img[src$='sample_man.png']")
     expect(page).to have_current_path profile_path, ignore_query: true
   end
+
+  it '未ログインではプロフィールの編集ができないこと' do
+    visit edit_profile_path
+    expect(page).to have_content 'ログインしてください'
+    expect(page).to have_current_path login_path, ignore_query: true
+  end
 end

--- a/spec/system/workouts_spec.rb
+++ b/spec/system/workouts_spec.rb
@@ -99,4 +99,20 @@ RSpec.describe 'Workouts', js: true do
     expect(page).to have_selector("img[src$='sample.png']")
     expect(page).to have_current_path user_path(user), ignore_query: true
   end
+
+
+  it '他人の投稿を編集できないこと' do #コントローラーレベルのテスト(認可外でedit/:id => root_pathへリダイレクトもテストしたい)
+    another_user = create(:user)
+    login_as(another_user)
+    visit home_workouts_path
+    click_on 'ベンチプレス'
+    expect(page).not_to have_content '編集'
+  end
+
+  it '未ログインでも投稿の詳細表示できること' do
+    visit home_workouts_path
+    click_on 'ベンチプレス'
+    expect(page).to have_content '筋トレ詳細'
+    # current_pathのチェック追加
+  end
 end

--- a/spec/system/workouts_spec.rb
+++ b/spec/system/workouts_spec.rb
@@ -100,8 +100,7 @@ RSpec.describe 'Workouts', js: true do
     expect(page).to have_current_path user_path(user), ignore_query: true
   end
 
-
-  it '他人の投稿を編集できないこと' do #コントローラーレベルのテスト(認可外でedit/:id => root_pathへリダイレクトもテストしたい)
+  it '他人の投稿を編集できないこと' do # コントローラーレベルのテスト(認可外でedit/:id => root_pathへリダイレクトもテストしたい)
     another_user = create(:user)
     login_as(another_user)
     visit home_workouts_path


### PR DESCRIPTION
## 概要
### ログイン前、ログイン後のユーザー認可
-（ログイン前）各投稿の一覧、詳細を閲覧可
-（ログイン後）プロフィール登録後、投稿可
### 投稿機能の認可
- 投稿の持ち主はその投稿の編集、更新、削除が可能
- 投稿の持ち主でない場合には編集、更新、削除が不可（ビューにボタンを非表示かつコントローラーでトップへリダイレクト）

## 確認方法
概要に記載のようにログイン/未ログイン、他ユーザーの認可設定ができていることをブラウザとテストで確認


## 影響範囲
筋トレと食事に関するビュー全体に影響

## チェックリスト
- [x] Lint のチェックをパスした
- [x] テストをパスした

## コメント
- 未ログインユーザーでもユーザー詳細画面を表示できるようにする
- 今後、認可の部分はコントローラーレベルのテストも書く
- フォームオブジェクトのリファクタリングをしてコントローラーを見やすくするべき。
close #93 