### PR TITLE
[Modify users show#48] ユーザー詳細ページの修正

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,17 +1,12 @@
 class ApplicationController < ActionController::Base
   add_flash_types :success, :info, :warning, :danger
   before_action :require_login
-  before_action :set_user
+
+  private
 
   # ログイン済みユーザーかどうか確認(:require_loginのメソッドに追加)
   def not_authenticated
     flash[:warning] = t('defaults.message.require_login')
     redirect_to login_path
-  end
-
-  private
-
-  def set_user
-    @user = User.find(current_user.id) if logged_in?
   end
 end

--- a/app/controllers/meals_controller.rb
+++ b/app/controllers/meals_controller.rb
@@ -22,7 +22,7 @@ class MealsController < ApplicationController
   def create
     @meal_form = MealForm.new(meal_form_params)
     if @meal_form.save
-      redirect_to user_path(@user.id), success: t('defaults.message.created', item: Meal.model_name.human)
+      redirect_to user_path(current_user.id), success: t('defaults.message.created', item: Meal.model_name.human)
     else
       flash.now['danger'] = t('defaults.message.not_created', item: Meal.model_name.human)
       render :new, status: :unprocessable_entity
@@ -33,7 +33,7 @@ class MealsController < ApplicationController
     @meal_form = MealForm.new(meal_params)
 
     if @meal_form.update
-      redirect_to user_path(@user.id), success: t('defaults.message.updated', item: Meal.model_name.human)
+      redirect_to user_path(current_user), success: t('defaults.message.updated', item: Meal.model_name.human)
     else
       flash.now['danger'] = t('defaults.message.not_updated', item: Meal.model_name.human)
       render :edit, status: :unprocessable_entity
@@ -44,7 +44,7 @@ class MealsController < ApplicationController
     @meal = current_user.meals.find_by(id: params[:id])
     redirect_to root_url, status: :see_other if @meal.nil?
     @meal.destroy!
-    redirect_to user_path(@user.id), success: t('defaults.message.deleted', item: Meal.model_name.human)
+    redirect_to user_path(current_user), success: t('defaults.message.deleted', item: Meal.model_name.human)
   end
 
   def calorie_search

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -2,7 +2,7 @@ class UsersController < ApplicationController
   skip_before_action :require_login, only: %i[new create]
 
   def show
-    @user = User.find(current_user.id)
+    @user = User.find(params[:id])
     @workouts = @user.workouts.order(created_at: :desc)
     @meals = @user.meals.includes(:meal_details).order(created_at: :desc)
   end

--- a/app/controllers/workouts_controller.rb
+++ b/app/controllers/workouts_controller.rb
@@ -17,7 +17,7 @@ class WorkoutsController < ApplicationController
   def create
     @workout_form = WorkoutForm.new(workout_form_params)
     if @workout_form.save
-      redirect_to user_path(@user.id), success: t('defaults.message.created', item: Workout.model_name.human)
+      redirect_to user_path(current_user), success: t('defaults.message.created', item: Workout.model_name.human)
     else
       flash.now['danger'] = t('defaults.message.not_created', item: Workout.model_name.human)
       render :new, status: :unprocessable_entity
@@ -27,7 +27,7 @@ class WorkoutsController < ApplicationController
   def update
     @workout_form = WorkoutForm.new(workout_params)
     if @workout_form.update
-      redirect_to user_path(@user.id), success: t('defaults.message.updated', item: Workout.model_name.human)
+      redirect_to user_path(current_user), success: t('defaults.message.updated', item: Workout.model_name.human)
     else
       flash.now['danger'] = t('defaults.message.not_updated', item: Workout.model_name.human)
       render :edit, status: :unprocessable_entity
@@ -38,7 +38,7 @@ class WorkoutsController < ApplicationController
     @workout = current_user.workouts.find_by(id: params[:id])
     redirect_to root_url, status: :see_other if @workout.nil?
     @workout.destroy!
-    redirect_to user_path(@user.id), success: t('defaults.message.deleted', item: Workout.model_name.human)
+    redirect_to user_path(current_user), success: t('defaults.message.deleted', item: Workout.model_name.human)
   end
 
   private

--- a/app/views/meals/_meal.html.erb
+++ b/app/views/meals/_meal.html.erb
@@ -1,13 +1,12 @@
-<div id="meal-id-<%= meal.id %>">
-  <div class="card w-96 bg-base-100 shadow-xl">
+<div iid="meal-id-<%= meal.id %>" class="m-4">
+  <div class="card card-side bg-base-100 shadow-xl  border border-base-300">
+    <figure><%= image_tag meal.meal_images.last.variant(:thumb) if meal.meal_images.attached? %></figure>
     <div class="card-body">
-      <h4 class="card-title">
-        <%= link_to meal.meal_period_i18n, meal_path(meal.id) %>
-      </h4>
-      <h4><%= meal.meal_details.pluck(:meal_title).join(',')%></h4>
+      <h2 class="card-title"><%= meal.meal_period_i18n %></h2>
+      <p><%=  meal.meal_details.pluck(:meal_title).join(',') %></p>
       <p><%= meal.meal_details.pluck(:meal_calorie).sum %>kcal</p>
-      <div>
-        <%= image_tag meal.meal_images.last.variant(:thumb) if meal.meal_images.attached? %>
+      <div class="card-actions justify-center">
+        <button class="btn btn-accent btn-wide"><%= link_to '詳細', meal_path(meal.id) %></button>
       </div>
     </div>
   </div>

--- a/app/views/shared/_header.html.erb
+++ b/app/views/shared/_header.html.erb
@@ -9,7 +9,7 @@
     <div class="dropdown dropdown-end">
       <label tabindex="0" class="btn btn-ghost btn-circle avatar" id="header-avatar">
         <div class="w-10 rounded-full">
-          <%= image_tag @user.avatar.variant(:thumb) if @user.avatar.attached? %>
+          <%= image_tag current_user.avatar.variant(:thumb) if current_user.avatar.attached? %>
         </div>
       </label>
       <ul tabindex="0" class="mt-3 p-2 shadow menu menu-compact dropdown-content bg-base-100 rounded-box w-52 text-base-content">

--- a/app/views/shared/_sidebar.html.erb
+++ b/app/views/shared/_sidebar.html.erb
@@ -1,7 +1,7 @@
 <div class="sidebar hidden md:flex md:flex-col md:min-w-max md:p-4 md:bg-base-300">
   <nav class="text-center">
     <ul class="menu">
-      <li><%= link_to 'マイページ', user_path(@user.id) %><li>
+      <li><%= link_to 'マイページ', user_path(current_user.id) %><li>
       <li><%= link_to 'タイムライン', home_workouts_path %></li>
     </ul>
     <div class="menu dropdown dropdown-right my-4">
@@ -15,20 +15,20 @@
   <div class="side-profile text-center my-8 w-36">
     <div class="avatar">
       <div class="w-24 rounded-full ring ring-primary ring-offset-base-100 ring-offset-2">
-        <%= image_tag @user.avatar.variant(:thumb) if @user.avatar.attached? %>
+        <%= image_tag current_user.avatar.variant(:thumb) if current_user.avatar.attached? %>
       </div>
     </div>
     <div class="user-info">
       <h2 class="mt-4 font-bold text-lg">ユーザー名</h2>
-      <p><%= @user.name %><p>
+      <p><%= current_user.name %><p>
       <h2 class="mt-4 font-bold text-lg ">自己紹介</h2>
-      <p class="text-left"><%= @user.introduction %><p>
+      <p class="text-left"><%= current_user.introduction %><p>
     </div>
   </div>
 </div>
 
 <div class="btm-nav z-50 md:hidden bg-base-300">
-  <%= link_to user_path(@user.id) do %>
+  <%= link_to user_path(current_user.id) do %>
     <button>
       <svg xmlns="http://www.w3.org/2000/svg" class="h-5 w-5" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M3 12l2-2m0 0l7-7 7 7M5 10v10a1 1 0 001 1h3m10-11l2 2m-2-2v10a1 1 0 01-1 1h-3m-6 0a1 1 0 001-1v-4a1 1 0 011-1h2a1 1 0 011 1v4a1 1 0 001 1m-6 0h6" /></svg>
       <span class="btm-nav-label">マイページ</span>

--- a/app/views/shared/_sidebar.html.erb
+++ b/app/views/shared/_sidebar.html.erb
@@ -12,19 +12,6 @@
       </ul>
     </div>
   </nav>
-  <div class="side-profile text-center my-8 w-36">
-    <div class="avatar">
-      <div class="w-24 rounded-full ring ring-primary ring-offset-base-100 ring-offset-2">
-        <%= image_tag current_user.avatar.variant(:thumb) if current_user.avatar.attached? %>
-      </div>
-    </div>
-    <div class="user-info">
-      <h2 class="mt-4 font-bold text-lg">ユーザー名</h2>
-      <p><%= current_user.name %><p>
-      <h2 class="mt-4 font-bold text-lg ">自己紹介</h2>
-      <p class="text-left"><%= current_user.introduction %><p>
-    </div>
-  </div>
 </div>
 
 <div class="btm-nav z-50 md:hidden bg-base-300">

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -1,24 +1,65 @@
-<h1 class="text-5xl font-bold"><%= @user.name %>さんの<%= t '.title' %></h1>
-<h1 class="text-5xl font-bold text-amber-700">
-  <% if @user.target_calorie.present? %>
-    今日のノルマはあと <%= @user.target_calorie - @user.meal_details.pluck(:meal_calorie).sum %> kcalです
-  <% else %>
-    プロフィール設定して、目標カロリーを設定してください。
-  <% end%>
-</h1>
-<div class="container mx-auto px-8 w-full flex flex-row justify-between">
-  <div>
-    <% if @workouts.present? %>
-      <%= render @workouts %>
-    <% else %>
-      <p><%= t('.no_result') %></p>
-    <% end %>
+<div class="profile m-8 flex flex-col">
+  <h1 class="text-xl font-bold"><%= @user.name %>さんの<%= t '.title' %></h1>
+  
+  <div class="md:flex md:justify-around">
+    <div class="flex max-w-full">
+      <div class="avatar max-w-max my-8 mx-4">
+        <div class="w-24 h-24 rounded-full ring ring-primary ring-offset-base-100 ring-offset-2">
+          <%= image_tag @user.avatar.variant(:thumb) if @user.avatar.attached? %>
+        </div>
+      </div>
+      <div class="flex flex-col">
+        <div class="m-4">
+          <h2 class="font-bold text-lg">ユーザー名</h2>
+          <p><%= @user.name %><p>
+        </div>
+        <h1 class="text-xl font-bold text-amber-700 m-4">
+          <% if @user.target_calorie.present? %>
+            1日の目標カロリーは <%= @user.target_calorie %> kcalです
+          <% else %>
+            目標カロリー未設定です
+          <% end%>
+        </h1>
+      </div>
+    </div>
+
+    <div>
+      <div class="p-2">
+        <h2 class="font-bold text-lg">自己紹介</h2>
+        <p><%= @user.introduction %><p>
+      </div>
+      <div class="p-2">
+        <h2 class="font-bold text-lg">SNS</h2>
+        <p><%= @user.twitter_link if @user.twitter_link.present? %><p>
+        <p><%= @user.instagram_link if @user.instagram_link.present? %><p>
+        <p><%= @user.facebook_link if @user.facebook_link.present? %><p>
+      </div>
+    </div>
   </div>
-  <div>
-    <% if @meals.present? %>
-      <%= render @meals %>
-    <% else %>
-      <p><%= t('.no_result') %></p>
-    <% end %>
+</div>
+
+<div class="flex flex-col w-full">
+  <div class="grid card rounded-box">
+    <h1 class="text-xl font-bold mx-8 my-4">筋トレ投稿</h1>
+    <div class="md:flex md:flex-wrap md:justify-start justify-center">
+      <% if @workouts.present? %>
+        <%= render @workouts %>
+      <% else %>
+        <p><%= t('.no_result') %></p>
+      <% end %>
+    </div>
+  </div> 
+
+  <div class="divider"></div> 
+  
+  <div class="grid card rounded-box">
+    <h1 class="text-xl font-bold mx-8 my-4">食事投稿</h1>
+    <div class="md:flex md:flex-wrap md:justify-start justify-center">
+      <% if @meals.present? %>
+        <%= render @meals %>
+      <% else %>
+        <p><%= t('.no_result') %></p>
+      <% end %>
+    </div>
   </div>
 </div>

--- a/app/views/workouts/_workout.html.erb
+++ b/app/views/workouts/_workout.html.erb
@@ -1,10 +1,11 @@
-<div id="workout-id-<%= workout.id %>">
-  <div class="card w-200 bg-base-100 shadow-xl">
+<div id="workout-id-<%= workout.id %>" class="m-4 max-w-lg">
+  <div class="card card-side bg-base-100 shadow-xl border border-base-300">
+    <figure><%= image_tag workout.workout_images.last.variant(:thumb) if workout.workout_images.attached? %></figure>
     <div class="card-body">
-      <h4 class="card-title"><%= link_to workout.workout_title, workout_path(workout.id) %></h4>
-      <h5><%= workout.workout_date %></h5>
-      <div>
-        <%= image_tag workout.workout_images.last.variant(:thumb) if workout.workout_images.attached? %>
+      <h2 class="card-title"><%= workout.workout_title %></h2>
+      <p><%= workout.workout_date.strftime("%Y年%m月%d日") %></p>
+      <div class="card-actions justify-center">
+        <button class="btn btn-accent btn-wide"><%= link_to '詳細', workout_path(workout.id) %></button>
       </div>
     </div>
   </div>

--- a/spec/system/meals_spec.rb
+++ b/spec/system/meals_spec.rb
@@ -45,7 +45,7 @@ RSpec.describe 'Meals', js: true do
   it 'マイページの食事投稿をクリックすると食事詳細画面が表示されること' do
     login_as(user)
     visit user_path(user)
-    click_on '昼食'
+    click_button '詳細'
     expect(page).to have_content '食事詳細'
     # current_pathのチェック追加
   end
@@ -53,7 +53,7 @@ RSpec.describe 'Meals', js: true do
   it '食事詳細画面の編集ボタンをクリックすると編集画面に遷移すること' do
     login_as(user)
     visit user_path(user)
-    click_on '昼食'
+    click_button '詳細'
     click_button '編集'
     expect(page).to have_content '食事編集'
     # current_pathのチェック追加
@@ -62,7 +62,7 @@ RSpec.describe 'Meals', js: true do
   it '食事編集から項目を入力して更新をクリックすると更新できること' do
     login_as(user)
     visit user_path(user)
-    click_on '昼食'
+    click_button '詳細'
     click_button '編集'
     select '昼食', from: '食事タイミング'
     select '自炊', from: '食事タイプ'
@@ -86,7 +86,7 @@ RSpec.describe 'Meals', js: true do
   it '食事編集画面で削除をクリックすると削除できること' do
     login_as(user)
     visit user_path(user)
-    click_on '昼食'
+    click_button '詳細'
     click_button '編集'
     page.accept_confirm do
       click_on '削除する'
@@ -99,13 +99,13 @@ RSpec.describe 'Meals', js: true do
     another_user = create(:user)
     login_as(another_user)
     visit home_meals_path
-    click_on '昼食'
+    click_button '詳細'
     expect(page).not_to have_content '編集'
   end
 
   it '未ログインでも投稿の詳細表示できること' do
     visit home_meals_path
-    click_on '昼食'
+    click_button '詳細'
     expect(page).to have_content '食事詳細'
     # current_pathのチェック追加
   end

--- a/spec/system/workouts_spec.rb
+++ b/spec/system/workouts_spec.rb
@@ -36,7 +36,7 @@ RSpec.describe 'Workouts', js: true do
   it 'マイページの筋トレ投稿をクリックすると筋トレ詳細画面が表示されること' do
     login_as(user)
     visit user_path(user)
-    click_on 'ベンチプレス'
+    click_button '詳細'
     expect(page).to have_content '筋トレ詳細'
     # current_pathのチェック追加
   end
@@ -44,7 +44,7 @@ RSpec.describe 'Workouts', js: true do
   it '筋トレ詳細画面の編集ボタンをクリックすると編集画面に遷移すること' do
     login_as(user)
     visit user_path(user)
-    click_on 'ベンチプレス'
+    click_button '詳細'
     click_button '編集'
     expect(page).to have_content '筋トレ編集'
     # current_pathのチェック追加
@@ -53,7 +53,7 @@ RSpec.describe 'Workouts', js: true do
   it '筋トレ編集から項目を入力して更新をクリックすると更新できること' do
     login_as(user)
     visit user_path(user)
-    click_on 'ベンチプレス'
+    click_button '詳細'
     click_button '編集'
     fill_in '筋トレ日', with: Time.current
     fill_in '種目名', with: 'ベンチプレス'
@@ -71,7 +71,7 @@ RSpec.describe 'Workouts', js: true do
   it '筋トレ編集画面で削除をクリックすると削除できること' do
     login_as(user)
     visit user_path(user)
-    click_on 'ベンチプレス'
+    click_button '詳細'
     click_button '編集'
     page.accept_confirm do
       click_on '削除する'
@@ -83,7 +83,7 @@ RSpec.describe 'Workouts', js: true do
   it '筋トレ投稿編集画面から画像を変更できること' do
     login_as(user)
     visit user_path(user)
-    click_on 'ベンチプレス'
+    click_button '詳細'
     click_button '編集'
     fill_in '筋トレ日', with: Time.current
     fill_in '種目名', with: 'ベンチプレス'
@@ -104,13 +104,13 @@ RSpec.describe 'Workouts', js: true do
     another_user = create(:user)
     login_as(another_user)
     visit home_workouts_path
-    click_on 'ベンチプレス'
+    click_button '詳細'
     expect(page).not_to have_content '編集'
   end
 
   it '未ログインでも投稿の詳細表示できること' do
     visit home_workouts_path
-    click_on 'ベンチプレス'
+    click_button '詳細'
     expect(page).to have_content '筋トレ詳細'
     # current_pathのチェック追加
   end


### PR DESCRIPTION
## 概要
- サイドバーとヘッダーをcurrent_userを元に生成するように修正、それに伴ってコントローラーの記述も修正
- ユーザー詳細ページ（マイページ）を視認性がよくなるように修正（レスポンシブ対応）

## 確認方法
- ログイン後のヘッダーおよびサイドバーがcurrent_userとなっていることを確認
- スマホビューとPCビューでマイページが崩れていないことを確認

## 影響範囲
- application_controllerのメソッドを削除したため、コントローラー全体に影響
- テストで影響範囲はクリア済み

## チェックリスト
- [x] Lint のチェックをパスした
- [x] テストをパスした

## コメント
- デフォルトの画像がカードに挿入されるようにした方がいいかもしれない（ビュー崩れ防止）
- 食事投稿にも日付（eated_dateのような）カラムを追加すべき=>マイページで日付ごと検索できるようになる
close #48 