### PR TITLE
[Modify primary key integer to UUID#96]アプリ全体テーブルの主キーをuuid化

### DIFF
--- a/app/forms/meal_form.rb
+++ b/app/forms/meal_form.rb
@@ -6,7 +6,7 @@ class MealForm
   attribute :meal_type, :integer
   attribute :meal_memo, :string
   attribute :user_id
-  
+
   attribute :meal_title_first, :string
   attribute :meal_weight_first, :integer
   attribute :meal_calorie_first, :integer

--- a/app/forms/meal_form.rb
+++ b/app/forms/meal_form.rb
@@ -5,8 +5,8 @@ class MealForm
   attribute :meal_period, :integer
   attribute :meal_type, :integer
   attribute :meal_memo, :string
-  attribute :user_id, :big_integer
-
+  attribute :user_id
+  
   attribute :meal_title_first, :string
   attribute :meal_weight_first, :integer
   attribute :meal_calorie_first, :integer
@@ -16,7 +16,7 @@ class MealForm
   attribute :meal_title_third, :string
   attribute :meal_weight_third, :integer
   attribute :meal_calorie_third, :integer
-  attribute :meal_id, :big_integer
+  attribute :meal_id
   attribute :meal_images
 
   validates :meal_title_first, presence: true
@@ -26,7 +26,7 @@ class MealForm
   def save
     return false if invalid?
 
-    meal = Meal.create(meal_period:, meal_type:, meal_memo:, meal_images:, user_id:)
+    meal = Meal.create(meal_period:, meal_type:, meal_memo:, user_id:, meal_images:)
     meal.meal_details.build(meal_title: meal_title_first, meal_weight: meal_weight_first, meal_calorie: meal_calorie_first).save
     if meal_title_second.present?
       meal.meal_details.build(meal_title: meal_title_second, meal_weight: meal_weight_second,

--- a/app/forms/workout_form.rb
+++ b/app/forms/workout_form.rb
@@ -11,8 +11,8 @@ class WorkoutForm
   attribute :workout_memo, :string
   attribute :body_part_ids
   attribute :workout_images
-  attribute :user_id, :integer
-  attribute :workout_id, :integer
+  attribute :user_id
+  attribute :workout_id
 
   validates :workout_date, presence: true
   validates :workout_title, presence: true
@@ -26,7 +26,7 @@ class WorkoutForm
     return false if invalid?
 
     workout = Workout.create(workout_date:, workout_title:, workout_time:,
-                             workout_weight:, repetition_count:, set_count:, workout_memo:, workout_images:, user_id:)
+                             workout_weight:, repetition_count:, set_count:, workout_memo:, user_id:, workout_images:)
     body_part_ids.map(&:to_i).each do |body_part_id|
       WorkoutBodyPart.create(workout_id: workout.id, body_part_id:)
     end

--- a/config/initializers/generators.rb
+++ b/config/initializers/generators.rb
@@ -1,0 +1,3 @@
+Rails.application.config.generators do |g|
+  g.orm :active_record, primary_key_type: :uuid
+end

--- a/db/migrate/20221126011400_enable_extension_for_uuid.rb
+++ b/db/migrate/20221126011400_enable_extension_for_uuid.rb
@@ -1,0 +1,5 @@
+class EnableExtensionForUuid < ActiveRecord::Migration[7.0]
+  def change
+    enable_extension 'pgcrypto' unless extension_enabled?('pgcrypto')
+  end
+end

--- a/db/migrate/20221126011411_sorcery_core.rb
+++ b/db/migrate/20221126011411_sorcery_core.rb
@@ -1,6 +1,6 @@
 class SorceryCore < ActiveRecord::Migration[7.0]
   def change
-    create_table :users do |t|
+    create_table :users, id: :uuid do |t|
       t.string :name,             null: false
       t.string :email,            null: false, index: { unique: true }
       t.string :crypted_password

--- a/db/migrate/20221218053352_create_workouts.rb
+++ b/db/migrate/20221218053352_create_workouts.rb
@@ -1,6 +1,6 @@
 class CreateWorkouts < ActiveRecord::Migration[7.0]
   def change
-    create_table :workouts do |t|
+    create_table :workouts, id: :uuid do |t|
       t.datetime :workout_date
       t.string :workout_title
       t.integer :workout_time
@@ -8,7 +8,7 @@ class CreateWorkouts < ActiveRecord::Migration[7.0]
       t.integer :repetition_count
       t.integer :set_count
       t.text :workout_memo
-      t.references :user, null: false, foreign_key: true
+      t.references :user, null: false, foreign_key: true, type: :uuid
 
       t.timestamps
     end

--- a/db/migrate/20221218094257_create_body_parts.rb
+++ b/db/migrate/20221218094257_create_body_parts.rb
@@ -1,6 +1,6 @@
 class CreateBodyParts < ActiveRecord::Migration[7.0]
   def change
-    create_table :body_parts do |t|
+    create_table :body_parts, id: :uuid do |t|
       t.string :body_part_name, null: false
 
       t.timestamps

--- a/db/migrate/20221218095639_create_workout_body_parts.rb
+++ b/db/migrate/20221218095639_create_workout_body_parts.rb
@@ -1,8 +1,8 @@
 class CreateWorkoutBodyParts < ActiveRecord::Migration[7.0]
   def change
-    create_table :workout_body_parts do |t|
-      t.references :workout, null: false, foreign_key: true
-      t.references :body_part, null: false, foreign_key: true
+    create_table :workout_body_parts, id: :uuid do |t|
+      t.references :workout, null: false, foreign_key: true, type: :uuid
+      t.references :body_part, null: false, foreign_key: true, type: :uuid
 
       t.timestamps
     end

--- a/db/migrate/20221225030651_create_meals.rb
+++ b/db/migrate/20221225030651_create_meals.rb
@@ -1,10 +1,10 @@
 class CreateMeals < ActiveRecord::Migration[7.0]
   def change
-    create_table :meals do |t|
+    create_table :meals, id: :uuid do |t|
       t.integer :meal_period
       t.integer :meal_type
       t.text :meal_memo
-      t.references :user, null: false, foreign_key: true
+      t.references :user, null: false, foreign_key: true, type: :uuid
 
       t.timestamps
     end

--- a/db/migrate/20221225032543_create_meal_details.rb
+++ b/db/migrate/20221225032543_create_meal_details.rb
@@ -1,10 +1,10 @@
 class CreateMealDetails < ActiveRecord::Migration[7.0]
   def change
-    create_table :meal_details do |t|
+    create_table :meal_details, id: :uuid do |t|
       t.string :meal_title,   null: false
       t.integer :meal_weight, null: false
       t.integer :meal_calorie,     null: false
-      t.references :meal,     null: false, foreign_key: true
+      t.references :meal,     null: false, foreign_key: true, type: :uuid
 
       t.timestamps
     end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -12,19 +12,20 @@
 
 ActiveRecord::Schema[7.0].define(version: 2022_12_25_032543) do
   # These are extensions that must be enabled in order to support this database
+  enable_extension "pgcrypto"
   enable_extension "plpgsql"
 
-  create_table "active_storage_attachments", force: :cascade do |t|
+  create_table "active_storage_attachments", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
     t.string "name", null: false
     t.string "record_type", null: false
-    t.bigint "record_id", null: false
-    t.bigint "blob_id", null: false
+    t.uuid "record_id", null: false
+    t.uuid "blob_id", null: false
     t.datetime "created_at", null: false
     t.index ["blob_id"], name: "index_active_storage_attachments_on_blob_id"
     t.index ["record_type", "record_id", "name", "blob_id"], name: "index_active_storage_attachments_uniqueness", unique: true
   end
 
-  create_table "active_storage_blobs", force: :cascade do |t|
+  create_table "active_storage_blobs", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
     t.string "key", null: false
     t.string "filename", null: false
     t.string "content_type"
@@ -36,39 +37,39 @@ ActiveRecord::Schema[7.0].define(version: 2022_12_25_032543) do
     t.index ["key"], name: "index_active_storage_blobs_on_key", unique: true
   end
 
-  create_table "active_storage_variant_records", force: :cascade do |t|
-    t.bigint "blob_id", null: false
+  create_table "active_storage_variant_records", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
+    t.uuid "blob_id", null: false
     t.string "variation_digest", null: false
     t.index ["blob_id", "variation_digest"], name: "index_active_storage_variant_records_uniqueness", unique: true
   end
 
-  create_table "body_parts", force: :cascade do |t|
+  create_table "body_parts", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
     t.string "body_part_name", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
   end
 
-  create_table "meal_details", force: :cascade do |t|
+  create_table "meal_details", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
     t.string "meal_title", null: false
     t.integer "meal_weight", null: false
     t.integer "meal_calorie", null: false
-    t.bigint "meal_id", null: false
+    t.uuid "meal_id", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.index ["meal_id"], name: "index_meal_details_on_meal_id"
   end
 
-  create_table "meals", force: :cascade do |t|
+  create_table "meals", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
     t.integer "meal_period"
     t.integer "meal_type"
     t.text "meal_memo"
-    t.bigint "user_id", null: false
+    t.uuid "user_id", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.index ["user_id"], name: "index_meals_on_user_id"
   end
 
-  create_table "users", force: :cascade do |t|
+  create_table "users", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
     t.string "name", null: false
     t.string "email", null: false
     t.string "crypted_password"
@@ -92,16 +93,16 @@ ActiveRecord::Schema[7.0].define(version: 2022_12_25_032543) do
     t.index ["email"], name: "index_users_on_email", unique: true
   end
 
-  create_table "workout_body_parts", force: :cascade do |t|
-    t.bigint "workout_id", null: false
-    t.bigint "body_part_id", null: false
+  create_table "workout_body_parts", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
+    t.uuid "workout_id", null: false
+    t.uuid "body_part_id", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.index ["body_part_id"], name: "index_workout_body_parts_on_body_part_id"
     t.index ["workout_id"], name: "index_workout_body_parts_on_workout_id"
   end
 
-  create_table "workouts", force: :cascade do |t|
+  create_table "workouts", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
     t.datetime "workout_date"
     t.string "workout_title"
     t.integer "workout_time"
@@ -109,7 +110,7 @@ ActiveRecord::Schema[7.0].define(version: 2022_12_25_032543) do
     t.integer "repetition_count"
     t.integer "set_count"
     t.text "workout_memo"
-    t.bigint "user_id", null: false
+    t.uuid "user_id", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.index ["user_id"], name: "index_workouts_on_user_id"


### PR DESCRIPTION
## 概要
- アプリ全体のテーブルのidをuuidとした

## 確認方法
1. カラムを変更したので、`bin/rails db:migrate:reset`後に`bin/rails db:seed`を実行
2. 各テーブルの主キーがuuilとなっていることを確認

## 影響範囲
全てのリソースに対して影響

## チェックリスト

- [x] Lint のチェックをパスした
- [x] テストをパスした

## コメント
- 当初usersテーブルのみuuid化を試みたが、Active Storegeのリレーションがうまくいかなかったことと、リリース前段階であったことから、全テーブルについてuuidする方針に変更
- FormオブジェクトのActiveModel::Attributesで定義した型は一旦削除
close #96 
