### PR TITLE
[ssl_config#98]本番環境で常時SSL通信を使うように設定変更

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -46,7 +46,7 @@ Rails.application.configure do
   # config.action_cable.allowed_request_origins = [ "http://example.com", /http:\/\/example.*/ ]
 
   # Force all access to the app over SSL, use Strict-Transport-Security, and use secure cookies.
-  # config.force_ssl = true
+  config.force_ssl = true
 
   # Include generic and useful information about system operation, but avoid logging too much
   # information to avoid inadvertent exposure of personally identifiable information (PII).


### PR DESCRIPTION
## 概要
- AWS Route53で独自ドメイン取得後、cloudflareでHTTPS対応させた
- 本番環境では常時SSL通信を使うように設定を修正

## 確認方法
本番環境で常にhttpsで通信していることを確認


## 影響範囲
本番環境におけるアプリケーション全体

## チェックリスト
- [x] Lint のチェックをパスした
- [x] テストをパスした

## コメント
- サービス名を修正
close #98 
