### PR TITLE
[Degug and workouts show fix#100] 筋トレ部位がshowページに反映されないバグ修正とworkouts#show修正

### DIFF
--- a/app/controllers/workouts_controller.rb
+++ b/app/controllers/workouts_controller.rb
@@ -3,7 +3,7 @@ class WorkoutsController < ApplicationController
 
   def show
     @workout = Workout.find(params[:id])
-    @user =User.find(@workout.user_id)
+    @user = User.find(@workout.user_id)
   end
 
   def new

--- a/app/controllers/workouts_controller.rb
+++ b/app/controllers/workouts_controller.rb
@@ -3,6 +3,7 @@ class WorkoutsController < ApplicationController
 
   def show
     @workout = Workout.find(params[:id])
+    @user =User.find(@workout.user_id)
   end
 
   def new

--- a/app/forms/workout_form.rb
+++ b/app/forms/workout_form.rb
@@ -27,7 +27,7 @@ class WorkoutForm
 
     workout = Workout.create(workout_date:, workout_title:, workout_time:,
                              workout_weight:, repetition_count:, set_count:, workout_memo:, user_id:, workout_images:)
-    body_part_ids.map(&:to_i).each do |body_part_id|
+    body_part_ids.each do |body_part_id|
       WorkoutBodyPart.create(workout_id: workout.id, body_part_id:)
     end
   end

--- a/app/views/workouts/show.html.erb
+++ b/app/views/workouts/show.html.erb
@@ -1,20 +1,78 @@
-<h1 class="text-5xl font-bold"><%= t '.title' %></h1>
-<h1 class="text-5xl font-bold text-red-600"><%= User.find(@workout.user_id).name %></h1>
-<h1 class="text-5xl font-bold"><%= @workout.workout_date.strftime("%Y年%m月%d日") %></h1>
-<h1 class="text-5xl font-bold"><%= @workout.workout_title %></h1>
-<h1 class="text-5xl font-bold"><%= @workout.body_parts.pluck(:body_part_name) %></h1>
-<h1 class="text-5xl font-bold">id <%= params[:id] %></h1>
-<% if @workout.workout_images.attached? %>
-  <% @workout.workout_images.each do |workout_image|%>
-  <div class="px-8">
-    <h2 class="text-xl py-6 font-bold">筋トレ画像</h2>
-    <%= image_tag workout_image.variant(:thumb) if workout_image.representable? %>
+<div class="profile m-8 flex flex-col w-full">
+  <h1 class="text-xl font-bold"><%= t '.title' %></h1>
+    <div class="grid card rounded-box place-items-center">
+      <div class="flex max-w-full">
+        <div class="avatar max-w-max my-8 mx-4">
+          <div class="w-24 h-24 rounded-full ring ring-primary ring-offset-base-100 ring-offset-2">
+            <%= image_tag @user.avatar.variant(:thumb) if @user.avatar.attached? %>
+          </div>
+        </div>
+        <div class="flex flex-col">
+          <div class="m-4">
+            <h2 class="font-bold text-lg">ユーザー名</h2>
+            <p><%= @user.name %><p>
+          </div>
+          <h1 class="text-xl font-bold text-amber-700 m-4">
+            <% if @user.target_calorie.present? %>
+              1日の目標カロリーは <%= @user.target_calorie %> kcalです
+            <% else %>
+              目標カロリー未設定です
+            <% end%>
+          </h1>
+        </div>
+      </div>
+    </div> 
+    <div class="divider"></div> 
+    <div class="grid card rounded-box">
+      <div class="flex justify-around">
+        <div class="w-2/5 flex flex-col align-center">
+          <h1 class="text-xl font-bold my-4 text-center"><%= @workout.workout_date.strftime("%Y年%m月%d日") %></h1>
+          <% if @workout.workout_images.attached? %>
+            <% @workout.workout_images.each do |workout_image|%>
+            <%# <div class="workout-images mx-8 my-4"> %>
+              <%= image_tag workout_image.variant(:thumb), class: "flex items-center mx-auto" if workout_image.representable? %>
+            <%# </div> %>
+            <% end %>
+          <% end %>
+        </div>
+        <div class="w-3/5 flex flex-col">
+          <div class="mx-8 mt-4">
+            <h1 class="text-xl font-bold">メニュー名</h1>
+            <p class="text-base"><%= @workout.workout_title %></p>
+          </div>
+          <div class="mx-8 mt-4">
+            <h1 class="text-xl font-bold">トレーニング部位</h1>
+            <p class="text-base"><%= @workout.body_parts.pluck(:body_part_name).join(' , ') %></p>
+          </div>
+          <div class="mx-8 mt-4">
+            <h1 class="text-xl font-bold">重量 / 回数 / セット数</h1>
+            <p class="text-base">
+            <%= @workout.workout_weight %> kg /
+            <%= @workout.repetition_count %> reps /
+            <%= @workout.set_count %> sets 
+            </p>
+          </div>
+          <div class="mx-8 mt-4">
+            <h1 class="text-xl font-bold">メモ</h1>
+            <p class="text-base md:w-96"><%= @workout.workout_memo %></p>
+          </div>
+          <div class="mx-8 mt-4">
+          <% if logged_in? && current_user.own?(@workout) %>
+            <%=link_to edit_workout_path(@workout), class: "btn btn-active btn-primary" do %>
+              <button><%= (t '.to_edit_page') %></button>
+            <% end %>
+          <% end %>
+          </div>
+        </div>
+      </div>
+    </div>
   </div>
-  <% end %>
-<% end %>
-<% if logged_in? && current_user.own?(@workout) %>
-  <button class="btn btn-active btn-primary">
-    <%= link_to (t '.to_edit_page'), edit_workout_path(@workout) %>
-  </button>
-<% end %>
+</div>
+
+
+
+
+
+
+
 


### PR DESCRIPTION
## 概要
- 筋トレ部位がnewやeditのページには表示されているのに、showで表示されていない
- 原因として昨日全てのテーブルの主キーをuuid化したことが考えれられる。
- Workoutフォームオブジェクトのsaveメソッドで、配列中の文字列idをintegerとして配列にしなおしてeachで処理する記述があった。これが原因と考えられる。
- uid化したことで、文字列として処理する記述に変更。
- workouts#showページも情報を整理し直して、最低限のレスポンシブ対応


## 確認方法
- workouts#show画面に筋トレ部位が表示されることを確認
- ブラウザ上でworkouts#showがレスポンシブ対応していることを確認

## 影響範囲
workoutモデルの保存処理に関係する部分に影響

## チェックリスト
- [x] Lint のチェックをパスした
- [x] テストをパスした

## コメント
- workouts#showなどはデフォルトの画像があった方がよいかも
- テストでこのバグを検出できなかったため、show画面のUIが決定次第エクスペクテーションを追加するべき
close #100 