### PR TITLE
[Add colum and fix meals show#102]mealsテーブルに日付のカラム追加、meals#showページの修正

### DIFF
--- a/app/controllers/meals_controller.rb
+++ b/app/controllers/meals_controller.rb
@@ -90,7 +90,7 @@ class MealsController < ApplicationController
   private
 
   def meal_form_params
-    params.require(:meal_form).permit(:meal_period, :meal_type, :meal_memo,
+    params.require(:meal_form).permit(:meal_date, :meal_period, :meal_type, :meal_memo,
                                       :meal_title_first, :meal_weight_first, :meal_calorie_first,
                                       :meal_title_second, :meal_weight_second, :meal_calorie_second,
                                       :meal_title_third, :meal_weight_third, :meal_calorie_third,
@@ -98,7 +98,7 @@ class MealsController < ApplicationController
   end
 
   def meal_params
-    params.require(:meal).permit(:meal_period, :meal_type, :meal_memo,
+    params.require(:meal).permit(:meal_date, :meal_period, :meal_type, :meal_memo,
                                  :meal_title_first, :meal_weight_first, :meal_calorie_first,
                                  :meal_title_second, :meal_weight_second, :meal_calorie_second,
                                  :meal_title_third, :meal_weight_third, :meal_calorie_third,

--- a/app/controllers/meals_controller.rb
+++ b/app/controllers/meals_controller.rb
@@ -8,6 +8,7 @@ class MealsController < ApplicationController
 
   def show
     @meal = Meal.find(params[:id])
+    @user = User.find(@meal.user_id)
   end
 
   def new

--- a/app/forms/meal_form.rb
+++ b/app/forms/meal_form.rb
@@ -1,7 +1,7 @@
 class MealForm
   include ActiveModel::Model
   include ActiveModel::Attributes
-  
+
   attribute :meal_date, :datetime
   attribute :meal_period, :integer
   attribute :meal_type, :integer

--- a/app/forms/meal_form.rb
+++ b/app/forms/meal_form.rb
@@ -1,7 +1,8 @@
 class MealForm
   include ActiveModel::Model
   include ActiveModel::Attributes
-
+  
+  attribute :meal_date, :datetime
   attribute :meal_period, :integer
   attribute :meal_type, :integer
   attribute :meal_memo, :string
@@ -19,6 +20,7 @@ class MealForm
   attribute :meal_id
   attribute :meal_images
 
+  validates :meal_date, presence: true
   validates :meal_title_first, presence: true
   validates :meal_weight_first, presence: true
   validates :meal_calorie_first, presence: true
@@ -26,7 +28,7 @@ class MealForm
   def save
     return false if invalid?
 
-    meal = Meal.create(meal_period:, meal_type:, meal_memo:, user_id:, meal_images:)
+    meal = Meal.create(meal_date:, meal_period:, meal_type:, meal_memo:, user_id:, meal_images:)
     meal.meal_details.build(meal_title: meal_title_first, meal_weight: meal_weight_first, meal_calorie: meal_calorie_first).save
     if meal_title_second.present?
       meal.meal_details.build(meal_title: meal_title_second, meal_weight: meal_weight_second,
@@ -43,7 +45,7 @@ class MealForm
     return false if invalid?
 
     meal = Meal.find(meal_id)
-    meal.update!(meal_period:, meal_type:, meal_memo:, meal_images:, user_id:)
+    meal.update!(meal_date:, meal_period:, meal_type:, meal_memo:, meal_images:, user_id:)
     MealDetail.where(meal_id: meal.id).delete_all
     meal.meal_details.build(meal_title: meal_title_first, meal_weight: meal_weight_first, meal_calorie: meal_calorie_first).save
     if meal_title_second.present?

--- a/app/views/meals/edit.html.erb
+++ b/app/views/meals/edit.html.erb
@@ -3,6 +3,10 @@
   <%= form_with model: @meal_form, url: meal_path, local: true do |f| %>
   <%= render 'shared/error_messages', object: f.object %>
     <div class="form-control">
+      <%= f.label :meal_date %>
+      <%= f.date_field :meal_date, class: "input input-bordered" %>
+    </div>
+    <div class="form-control">
       <%= f.label :meal_period %>
       <%= f.select :meal_period, Meal.meal_periods_i18n.invert.map{|key, value| [key, Meal.meal_periods[value]]}, class: "input input-bordered" %>
     </div>

--- a/app/views/meals/new.html.erb
+++ b/app/views/meals/new.html.erb
@@ -8,6 +8,10 @@
     <%= form_with model: @meal_form, url: meals_path, local: true do |f| %>
     <%= render 'shared/error_messages', object: f.object %>
       <div class="form-control">
+        <%= f.label :meal_date %>
+        <%= f.date_field :meal_date, class: "input input-bordered" %>
+      </div>
+      <div class="form-control">
         <%= f.label :meal_period %>
         <%= f.select :meal_period, Meal.meal_periods_i18n.invert.map{|key, value| [key, Meal.meal_periods[value]]}, class: "input input-bordered" %>
       </div>

--- a/app/views/meals/show.html.erb
+++ b/app/views/meals/show.html.erb
@@ -1,21 +1,69 @@
-<h1 class="text-5xl font-bold"><%= t '.title' %></h1>
-<h1 class="text-5xl font-bold text-red-600"><%= User.find(@meal.user_id).name %></h1>
-<h1 class="text-5xl font-bold"><%= @meal.meal_period_i18n %></h1>
-<h1 class="text-5xl font-bold"><%= @meal.meal_type_i18n %></h1>
-<h1 class="text-5xl font-bold"><%= @meal.meal_details.pluck(:meal_title) %></h1>
-<h1 class="text-5xl font-bold"><%= @meal.meal_details.pluck(:meal_calorie) %></h1>
-<h1 class="text-5xl font-bold"><%= @meal.meal_details.pluck(:meal_weight) %></h1>
-<h1 class="text-5xl font-bold">id <%= params[:id] %></h1>
-<% if @meal.meal_images.attached? %>
-  <% @meal.meal_images.each do |meal_image|%>
-  <div class="px-8">
-    <h2 class="text-xl py-6 font-bold">食事画像</h2>
-    <%= image_tag meal_image.variant(:thumb) if meal_image.representable? %>
+<div class="profile m-8 flex flex-col w-full">
+  <h1 class="text-xl font-bold"><%= t '.title' %></h1>
+    <div class="grid card rounded-box place-items-center">
+      <div class="flex max-w-full">
+        <div class="avatar max-w-max my-8 mx-4">
+          <div class="w-24 h-24 rounded-full ring ring-primary ring-offset-base-100 ring-offset-2">
+            <%= image_tag @user.avatar.variant(:thumb) if @user.avatar.attached? %>
+          </div>
+        </div>
+        <div class="flex flex-col">
+          <div class="m-4">
+            <h2 class="font-bold text-lg">ユーザー名</h2>
+            <p><%= @user.name %><p>
+          </div>
+          <h1 class="text-xl font-bold text-amber-700 m-4">
+            <% if @user.target_calorie.present? %>
+              1日の目標カロリーは <%= @user.target_calorie %> kcalです
+            <% else %>
+              目標カロリー未設定です
+            <% end%>
+          </h1>
+        </div>
+      </div>
+    </div> 
+    <div class="divider"></div> 
+    <div class="grid card rounded-box">
+      <div class="flex justify-around">
+        <div class="w-2/5 flex flex-col align-center">
+          <h1 class="text-xl font-bold my-4 text-center"><%= @meal.meal_date.strftime("%Y年%m月%d日") %></h1>
+          <% if @meal.meal_images.attached? %>
+            <% @meal.meal_images.each do |meal_image|%>
+              <%= image_tag meal_image.variant(:thumb), class: "flex items-center mx-auto" if meal_image.representable? %>
+            <% end %>
+          <% end %>
+        </div>
+        <div class="w-3/5 flex flex-col">
+          <div class="mx-8 mt-4">
+            <h1 class="text-xl font-bold">メニュー名</h1>
+            <p class="text-base"><%= @meal.meal_details.pluck(:meal_title).join(' , ') %></p>
+          </div>
+          <div class="mx-8 mt-4">
+            <h1 class="text-xl font-bold">食事タイミング</h1>
+            <p class="text-base"><%= @meal.meal_period_i18n %></p>
+          </div>
+          <div class="mx-8 mt-4">
+            <h1 class="text-xl font-bold">食事タイプ</h1>
+            <p class="text-base"><%= @meal.meal_type_i18n %></p>
+          </div>
+          <div class="mx-8 mt-4">
+            <h1 class="text-xl font-bold">カロリー</h1>
+            <p class="text-base"><%= @meal.meal_details.pluck(:meal_calorie).sum %> kcal</p>
+          </div>
+          <div class="mx-8 mt-4">
+            <h1 class="text-xl font-bold">メモ</h1>
+            <p class="text-base md:w-96"><%= @meal.meal_memo %></p>
+          </div>
+          <div class="mx-8 mt-4">
+          <% if logged_in? && current_user.own?(@meal) %>
+            <%=link_to edit_meal_path(@meal), class: "btn btn-active btn-primary" do %>
+              <button><%= (t '.to_edit_page') %></button>
+            <% end %>
+          <% end %>
+          </div>
+        </div>
+      </div>
+    </div>
   </div>
-  <% end %>
-<% end %>
-<% if logged_in? && current_user.own?(@meal)%>
-  <button class="btn btn-active btn-primary">
-    <%= link_to (t '.to_edit_page'), edit_meal_path(@meal) %>
-  </button>
-<% end %>
+</div>
+

--- a/config/locales/activerecord/ja.yml
+++ b/config/locales/activerecord/ja.yml
@@ -35,6 +35,7 @@ ja:
         body_part_ids: "筋トレ部位"
         workout_images: "筋トレ画像（複数登録可）"
       meal:
+        meal_date: "日付"
         meal_period: "食事タイミング"
         meal_type: "食事タイプ"
         meal_memo: "メモ"
@@ -63,6 +64,7 @@ ja:
         body_part_ids: "筋トレ部位"
         workout_images: "筋トレ画像（複数登録可）"
       meal_form:
+        meal_date: "日付"
         meal_period: "食事タイミング"
         meal_type: "食事タイプ"
         meal_memo: "メモ"

--- a/db/migrate/20221225030651_create_meals.rb
+++ b/db/migrate/20221225030651_create_meals.rb
@@ -1,6 +1,7 @@
 class CreateMeals < ActiveRecord::Migration[7.0]
   def change
     create_table :meals, id: :uuid do |t|
+      t.datetime :meal_date
       t.integer :meal_period
       t.integer :meal_type
       t.text :meal_memo

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -60,6 +60,7 @@ ActiveRecord::Schema[7.0].define(version: 2022_12_25_032543) do
   end
 
   create_table "meals", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
+    t.datetime "meal_date"
     t.integer "meal_period"
     t.integer "meal_type"
     t.text "meal_memo"

--- a/db/seeds/development.rb
+++ b/db/seeds/development.rb
@@ -74,7 +74,7 @@ end
   body_part = BodyPart.offset(rand(BodyPart.count)).first
 
   Workout.create!(
-    user: user,
+    user: first_user,
     workout_date: workout_date,
     workout_title: workout_title,
     workout_time: workout_time,
@@ -87,7 +87,7 @@ end
   ).save!
 
   Workout.create!(
-    user: first_user,
+    user: user,
     workout_date: workout_date,
     workout_title: workout_title,
     workout_time: workout_time,
@@ -104,6 +104,7 @@ end
 20.times do |n|
   first_user = User.first
   user = User.offset(rand(User.count)).first
+  meal_date = Time.now + 24 * 60 * 60 * n
   meal_period = 'lunch'
   meal_type = 'eating_out'
   meal_memo = Faker::Lorem.sentence
@@ -113,6 +114,7 @@ end
 
   Meal.create!(
     user: first_user,
+    meal_date: meal_date,
     meal_period: meal_period,
     meal_type: meal_type,
     meal_memo: meal_memo
@@ -124,6 +126,7 @@ end
 
   Meal.create!(
     user: user,
+    meal_date: meal_date,
     meal_period: meal_period,
     meal_type: meal_type,
     meal_memo: meal_memo

--- a/spec/system/meals_spec.rb
+++ b/spec/system/meals_spec.rb
@@ -5,6 +5,7 @@ RSpec.describe 'Meals', js: true do
 
   before do
     MealForm.new(
+      meal_date: Time.current,
       meal_period: 1,
       meal_type: 1,
       meal_title_first: '唐揚げ',
@@ -23,6 +24,7 @@ RSpec.describe 'Meals', js: true do
   it '新規食事投稿画面から食事の記録を登録できること' do
     login_as(user)
     visit new_meal_path
+    fill_in '日付', with: Time.current
     select '昼食', from: '食事タイミング'
     select '外食', from: '食事タイプ'
     fill_in 'メニューその1', with: '唐揚げ'
@@ -64,6 +66,7 @@ RSpec.describe 'Meals', js: true do
     visit user_path(user)
     click_button '詳細'
     click_button '編集'
+    fill_in '日付', with: Time.current
     select '昼食', from: '食事タイミング'
     select '自炊', from: '食事タイプ'
     fill_in 'メニューその1', with: 'お弁当'


### PR DESCRIPTION
## 概要
- mealsテーブルにmeal_dateカラム（datetime型）を追加
- meals#showのcss修正

## 確認方法
1. カラムを追加したので `bin/rails db:migrate` 、`bin/rails db:seed`を実行
2. meals#show画面に日付が表示されていることを確認

## 影響範囲
mealsリソースに関係する部分に影響します。

## チェックリスト
- [x] Lint のチェックをパスした
- [x] テストをパスした

## コメント
- マイページで日付ソートできる機能をつける
- 日付ごとカロリー摂取の達成状況を表示できるといい
