### PR TITLE
[fix_meal_form_bugs#66] (食事投稿)フォームオブジェクトのリファクタリング、食事投稿のバグ修正

### DIFF
--- a/app/controllers/meals_controller.rb
+++ b/app/controllers/meals_controller.rb
@@ -43,7 +43,7 @@ class MealsController < ApplicationController
     if @meal_form.save
       if params.dig(:meal, :meal_images)[1].present?
         images = ActiveStorage::Attachment.where(record_id: params[:id])
-        images.map(&:purge)
+        images.each {|image| image.purge }
         @meal.meal_images.attach(params[:meal][:meal_images])
       end
       redirect_to user_path(current_user), success: t('defaults.message.updated', item: Meal.model_name.human)

--- a/app/controllers/meals_controller.rb
+++ b/app/controllers/meals_controller.rb
@@ -38,9 +38,14 @@ class MealsController < ApplicationController
 
   def update
     load_meal
-
+    
     @meal_form = MealForm.new(meal_params, meal: @meal)
     if @meal_form.save
+      if params.dig(:meal, :meal_images)[1].present?
+        images = ActiveStorage::Attachment.where(record_id: params[:id])
+        images.map(&:purge)
+        @meal.meal_images.attach(params[:meal][:meal_images])
+      end
       redirect_to user_path(current_user), success: t('defaults.message.updated', item: Meal.model_name.human)
     else
       flash.now['danger'] = t('defaults.message.not_updated', item: Meal.model_name.human)

--- a/app/controllers/meals_controller.rb
+++ b/app/controllers/meals_controller.rb
@@ -20,12 +20,15 @@ class MealsController < ApplicationController
   end
 
   def edit
-    @meal_form = current_user.meals.find_by(id: params[:id])
+    load_meal
+
+    @meal_form = MealForm.new(meal: @meal)
     redirect_to root_url, status: :see_other if @meal_form.nil?
   end
 
   def create
-    @meal_form = MealForm.new(meal_form_params)
+    debugger
+    @meal_form = MealForm.new(meal_params)
     if @meal_form.save
       redirect_to user_path(current_user.id), success: t('defaults.message.created', item: Meal.model_name.human)
     else
@@ -35,9 +38,11 @@ class MealsController < ApplicationController
   end
 
   def update
-    @meal_form = MealForm.new(meal_params)
+    load_meal
+    debugger
+    @meal_form = MealForm.new(meal_params, meal: @meal)
 
-    if @meal_form.update
+    if @meal_form.save
       redirect_to user_path(current_user), success: t('defaults.message.updated', item: Meal.model_name.human)
     else
       flash.now['danger'] = t('defaults.message.not_updated', item: Meal.model_name.human)
@@ -46,7 +51,7 @@ class MealsController < ApplicationController
   end
 
   def destroy
-    @meal = current_user.meals.find_by(id: params[:id])
+    @meal = current_user.meals.find(params[:id])
     redirect_to root_url, status: :see_other if @meal.nil?
     @meal.destroy!
     redirect_to user_path(current_user), success: t('defaults.message.deleted', item: Meal.model_name.human)
@@ -93,20 +98,16 @@ class MealsController < ApplicationController
 
   private
 
-  def meal_form_params
-    params.require(:meal_form).permit(:meal_date, :meal_period, :meal_type, :meal_memo,
-                                      :meal_title_first, :meal_weight_first, :meal_calorie_first,
-                                      :meal_title_second, :meal_weight_second, :meal_calorie_second,
-                                      :meal_title_third, :meal_weight_third, :meal_calorie_third,
-                                      meal_images: []).merge(user_id: current_user.id)
-  end
-
   def meal_params
     params.require(:meal).permit(:meal_date, :meal_period, :meal_type, :meal_memo,
                                  :meal_title_first, :meal_weight_first, :meal_calorie_first,
                                  :meal_title_second, :meal_weight_second, :meal_calorie_second,
                                  :meal_title_third, :meal_weight_third, :meal_calorie_third,
                                  meal_images: []).merge(user_id: current_user.id, meal_id: params[:id])
+  end
+
+  def load_meal
+    @meal = current_user.meals.find(params[:id])
   end
 
   def set_response

--- a/app/controllers/meals_controller.rb
+++ b/app/controllers/meals_controller.rb
@@ -27,7 +27,6 @@ class MealsController < ApplicationController
   end
 
   def create
-    debugger
     @meal_form = MealForm.new(meal_params)
     if @meal_form.save
       redirect_to user_path(current_user.id), success: t('defaults.message.created', item: Meal.model_name.human)
@@ -39,9 +38,8 @@ class MealsController < ApplicationController
 
   def update
     load_meal
-    debugger
-    @meal_form = MealForm.new(meal_params, meal: @meal)
 
+    @meal_form = MealForm.new(meal_params, meal: @meal)
     if @meal_form.save
       redirect_to user_path(current_user), success: t('defaults.message.updated', item: Meal.model_name.human)
     else

--- a/app/forms/meal_form.rb
+++ b/app/forms/meal_form.rb
@@ -25,6 +25,15 @@ class MealForm
   validates :meal_weight_first, presence: true
   validates :meal_calorie_first, presence: true
 
+  delegate :persisted?, to: :meal
+
+  def initialize(attributes = nil, meal: Meal.new)
+    @meal = meal
+    attributes ||= default_attributes
+    super(attributes)
+  end
+
+
   def save
     return false if invalid?
 
@@ -41,21 +50,31 @@ class MealForm
     meal
   end
 
-  def update
-    return false if invalid?
 
-    meal = Meal.find(meal_id)
-    meal.update!(meal_date:, meal_period:, meal_type:, meal_memo:, meal_images:, user_id:)
-    MealDetail.where(meal_id: meal.id).delete_all
-    meal.meal_details.build(meal_title: meal_title_first, meal_weight: meal_weight_first, meal_calorie: meal_calorie_first).save
-    if meal_title_second.present?
-      meal.meal_details.build(meal_title: meal_title_second, meal_weight: meal_weight_second,
-                              meal_calorie: meal_calorie_second).save
-    end
-    if meal_title_third.present?
-      meal.meal_details.build(meal_title: meal_title_third, meal_weight: meal_weight_third,
-                              meal_calorie: meal_calorie_third).save
-    end
+  def to_model
     meal
+  end
+
+  private
+
+  attr_reader :meal
+
+  def default_attributes
+    {
+      user_id: meal.user_id,
+      meal_date: meal.meal_date,
+      meal_period: meal.meal_period_before_type_cast,
+      meal_type: meal.meal_period_before_type_cast,
+      meal_memo: meal.meal_memo,
+      meal_title_first:"#{meal.meal_details.first.meal_title unless meal.meal_details.first.nil?}",
+      meal_weight_first: "#{meal.meal_details.first.meal_title unless meal.meal_details.first.nil?}",
+      meal_calorie_first: "#{meal.meal_details.first.meal_calorie unless meal.meal_details.first.nil?}",
+      meal_title_second: "#{meal.meal_details.second.meal_title unless meal.meal_details.second.nil?}",
+      meal_weight_second: "#{meal.meal_details.second.meal_title unless meal.meal_details.second.nil?}",
+      meal_calorie_second: "#{meal.meal_details.second.meal_calorie unless meal.meal_details.second.nil?}",
+      meal_title_third: "#{meal.meal_details.third.meal_title unless meal.meal_details.third.nil?}",
+      meal_weight_third: "#{meal.meal_details.third.meal_weight unless meal.meal_details.third.nil?}",
+      meal_calorie_third: "#{meal.meal_details.third.meal_calorie unless meal.meal_details.third.nil?}"
+    }
   end
 end

--- a/app/forms/meal_form.rb
+++ b/app/forms/meal_form.rb
@@ -37,12 +37,23 @@ class MealForm
     return false if invalid?
 
     ActiveRecord::Base.transaction do
-      meal = Meal.create(meal_date:, meal_period:, meal_type:, meal_memo:, user_id:, meal_images:)
-      meal.meal_details.build(meal_title: meal_title_first, meal_weight: meal_weight_first, meal_calorie: meal_calorie_first).save
+      if meal.meal_images.blank?
+        meal.update!(meal_date:, meal_period:, meal_type:, meal_memo:, user_id:, meal_images:)
+      else
+        meal.update!(meal_date:, meal_period:, meal_type:, meal_memo:, user_id:)
+      end
+
+      if meal.meal_details.blank?
+        meal.meal_details.create!(meal_title: meal_title_first, meal_weight: meal_weight_first, meal_calorie: meal_calorie_first)
+      else
+        meal.meal_details.update!(meal_title: meal_title_first, meal_weight: meal_weight_first, meal_calorie: meal_calorie_first)
+      end
+
       unless meal_title_second.empty?
         meal.meal_details.build(meal_title: meal_title_second, meal_weight: meal_weight_second,
                                 meal_calorie: meal_calorie_second).save
       end
+
       unless meal_title_third.empty?
         meal.meal_details.build(meal_title: meal_title_third, meal_weight: meal_weight_third,
                                 meal_calorie: meal_calorie_third).save
@@ -77,6 +88,7 @@ class MealForm
       meal_period: meal.meal_period_before_type_cast,
       meal_type: meal.meal_period_before_type_cast,
       meal_memo: meal.meal_memo,
+      meal_images: meal.meal_images,
       meal_title_first:,
       meal_weight_first:,
       meal_calorie_first:,

--- a/app/forms/meal_form.rb
+++ b/app/forms/meal_form.rb
@@ -37,19 +37,16 @@ class MealForm
   def save
     return false if invalid?
 
-    meal = Meal.create(meal_date:, meal_period:, meal_type:, meal_memo:, user_id:, meal_images:)
-    meal.meal_details.build(meal_title: meal_title_first, meal_weight: meal_weight_first, meal_calorie: meal_calorie_first).save
-    if meal_title_second.present?
-      meal.meal_details.build(meal_title: meal_title_second, meal_weight: meal_weight_second,
-                              meal_calorie: meal_calorie_second).save
+    ActiveRecord::Base.transaction do
+      meal = Meal.create(meal_date:, meal_period:, meal_type:, meal_memo:, user_id:, meal_images:)
+      meal.meal_details.build(meal_title: meal_title_first, meal_weight: meal_weight_first, meal_calorie: meal_calorie_first).save
+      meal.meal_details.build(meal_title: meal_title_second, meal_weight: meal_weight_second, meal_calorie: meal_calorie_second).save unless meal_title_second.empty?
+      meal.meal_details.build(meal_title: meal_title_third, meal_weight: meal_weight_third, meal_calorie: meal_calorie_third).save unless meal_title_third.empty?
+      meal
     end
-    if meal_title_third.present?
-      meal.meal_details.build(meal_title: meal_title_third, meal_weight: meal_weight_third,
-                              meal_calorie: meal_calorie_third).save
-    end
-    meal
+  rescue ActiveRecord::RecordInvalid
+      false
   end
-
 
   def to_model
     meal
@@ -60,21 +57,30 @@ class MealForm
   attr_reader :meal
 
   def default_attributes
+    meal_title_first = meal.meal_details.first.nil? ? '' : meal.meal_details.first.meal_title
+    meal_weight_first = meal.meal_details.first.nil? ? '' : meal.meal_details.first.meal_weight
+    meal_calorie_first = meal.meal_details.first.nil? ? '' : meal.meal_details.first.meal_calorie
+    meal_title_second = meal.meal_details.second.nil? ? '' : meal.meal_details.second.meal_title
+    meal_weight_second = meal.meal_details.second.nil? ? '' : meal.meal_details.second.meal_weight
+    meal_calorie_second = meal.meal_details.second.nil? ? '' : meal.meal_details.second.meal_calorie
+    meal_title_third = meal.meal_details.third.nil? ? '' : meal.meal_details.third.meal_title
+    meal_weight_third = meal.meal_details.third.nil? ? '' : meal.meal_details.third.meal_weight
+    meal_calorie_third = meal.meal_details.third.nil? ? '' : meal.meal_details.third.meal_calorie
     {
       user_id: meal.user_id,
       meal_date: meal.meal_date,
       meal_period: meal.meal_period_before_type_cast,
       meal_type: meal.meal_period_before_type_cast,
       meal_memo: meal.meal_memo,
-      meal_title_first:"#{meal.meal_details.first.meal_title unless meal.meal_details.first.nil?}",
-      meal_weight_first: "#{meal.meal_details.first.meal_title unless meal.meal_details.first.nil?}",
-      meal_calorie_first: "#{meal.meal_details.first.meal_calorie unless meal.meal_details.first.nil?}",
-      meal_title_second: "#{meal.meal_details.second.meal_title unless meal.meal_details.second.nil?}",
-      meal_weight_second: "#{meal.meal_details.second.meal_title unless meal.meal_details.second.nil?}",
-      meal_calorie_second: "#{meal.meal_details.second.meal_calorie unless meal.meal_details.second.nil?}",
-      meal_title_third: "#{meal.meal_details.third.meal_title unless meal.meal_details.third.nil?}",
-      meal_weight_third: "#{meal.meal_details.third.meal_weight unless meal.meal_details.third.nil?}",
-      meal_calorie_third: "#{meal.meal_details.third.meal_calorie unless meal.meal_details.third.nil?}"
+      meal_title_first: meal_title_first,
+      meal_weight_first: meal_weight_first,
+      meal_calorie_first: meal_calorie_first,
+      meal_title_second: meal_title_second,
+      meal_weight_second: meal_weight_second,
+      meal_calorie_second: meal_calorie_second,
+      meal_title_third: meal_title_third,
+      meal_weight_third: meal_weight_third,
+      meal_calorie_third: meal_calorie_third
     }
   end
 end

--- a/app/forms/meal_form.rb
+++ b/app/forms/meal_form.rb
@@ -33,19 +33,24 @@ class MealForm
     super(attributes)
   end
 
-
   def save
     return false if invalid?
 
     ActiveRecord::Base.transaction do
       meal = Meal.create(meal_date:, meal_period:, meal_type:, meal_memo:, user_id:, meal_images:)
       meal.meal_details.build(meal_title: meal_title_first, meal_weight: meal_weight_first, meal_calorie: meal_calorie_first).save
-      meal.meal_details.build(meal_title: meal_title_second, meal_weight: meal_weight_second, meal_calorie: meal_calorie_second).save unless meal_title_second.empty?
-      meal.meal_details.build(meal_title: meal_title_third, meal_weight: meal_weight_third, meal_calorie: meal_calorie_third).save unless meal_title_third.empty?
+      unless meal_title_second.empty?
+        meal.meal_details.build(meal_title: meal_title_second, meal_weight: meal_weight_second,
+                                meal_calorie: meal_calorie_second).save
+      end
+      unless meal_title_third.empty?
+        meal.meal_details.build(meal_title: meal_title_third, meal_weight: meal_weight_third,
+                                meal_calorie: meal_calorie_third).save
+      end
       meal
     end
   rescue ActiveRecord::RecordInvalid
-      false
+    false
   end
 
   def to_model
@@ -72,15 +77,15 @@ class MealForm
       meal_period: meal.meal_period_before_type_cast,
       meal_type: meal.meal_period_before_type_cast,
       meal_memo: meal.meal_memo,
-      meal_title_first: meal_title_first,
-      meal_weight_first: meal_weight_first,
-      meal_calorie_first: meal_calorie_first,
-      meal_title_second: meal_title_second,
-      meal_weight_second: meal_weight_second,
-      meal_calorie_second: meal_calorie_second,
-      meal_title_third: meal_title_third,
-      meal_weight_third: meal_weight_third,
-      meal_calorie_third: meal_calorie_third
+      meal_title_first:,
+      meal_weight_first:,
+      meal_calorie_first:,
+      meal_title_second:,
+      meal_weight_second:,
+      meal_calorie_second:,
+      meal_title_third:,
+      meal_weight_third:,
+      meal_calorie_third:
     }
   end
 end

--- a/app/views/meals/edit.html.erb
+++ b/app/views/meals/edit.html.erb
@@ -69,6 +69,16 @@
       <%= f.label :meal_images, class: "text-xl pt-4 font-bold" %>
       <%= f.file_field :meal_images, class: "input input-bordered", multiple: true %>
     </div>
+    <div class="flex flex-col items-start my-3">
+      <% if @meal_form.meal_images.attached? %>
+        <h1 class="text-xl pt-4 font-bold">アップロード済み画像</h1>
+        <div class="flex flex-wrap">
+          <% @meal_form.meal_images.each do |meal_image|%>
+          <div><%= image_tag meal_image.variant(:thumb), class: "m-2" if meal_image.representable? %></div>
+          <% end %>
+        </div>
+      <% end %>
+    </div>
     <div class="flex flex-col items-center">
       <%= f.submit class: "btn btn-primary btn-wide my-4"%>
       <% end %>

--- a/app/views/meals/edit.html.erb
+++ b/app/views/meals/edit.html.erb
@@ -3,7 +3,7 @@
   <div>
     <%= render 'calorie_search', response: @response %>
   </div>
-  <%= form_with model: @meal_form, url: meal_path, local: true do |f| %>
+  <%= form_with model: @meal_form, local: true do |f| %>
   <%= render 'shared/error_messages', object: f.object %>
     <div class="form-control">
       <%= f.label :meal_date, class: "text-xl pt-4 font-bold" %>

--- a/app/views/meals/new.html.erb
+++ b/app/views/meals/new.html.erb
@@ -6,7 +6,7 @@
   </div>
 
   <div class="mt-6">
-    <%= form_with model: @meal_form, url: meals_path, local: true do |f| %>
+    <%= form_with model: @meal_form, local: true do |f| %>
     <%= render 'shared/error_messages', object: f.object %>
       <div class="form-control">
         <%= f.label :meal_date, class: "text-xl pt-4 font-bold" %>

--- a/app/views/meals/show.html.erb
+++ b/app/views/meals/show.html.erb
@@ -33,7 +33,7 @@
           <h1 class="text-xl font-bold my-4 text-center"><%= @meal.meal_date.strftime("%Y年%m月%d日") %></h1>
           <% if @meal.meal_images.attached? %>
             <% @meal.meal_images.each do |meal_image|%>
-              <%= image_tag meal_image.variant(:thumb), class: "flex items-center mx-auto" if meal_image.representable? %>
+              <%= image_tag meal_image.variant(:thumb), class: "flex items-center m-2" if meal_image.representable? %>
             <% end %>
           <% end %>
         </div>

--- a/spec/system/meal_form_spec.rb
+++ b/spec/system/meal_form_spec.rb
@@ -1,10 +1,11 @@
 require 'rails_helper'
 
-RSpec.describe 'Meals', js: true do
+RSpec.describe 'MealForm', js: true do
   let(:user) { create(:user) }
 
   before do
-    MealForm.new(
+    meal = MealForm.new
+    meal.assign_attributes(
       meal_date: Time.current,
       meal_period: 1,
       meal_type: 1,
@@ -18,7 +19,8 @@ RSpec.describe 'Meals', js: true do
       meal_weight_third: 100,
       meal_calorie_third: 100,
       user_id: user.id
-    ).save
+    )
+    meal.save
   end
 
   it '未ログインでも食事のタイムラインを閲覧できること' do
@@ -41,16 +43,16 @@ RSpec.describe 'Meals', js: true do
     select '昼食', from: '食事タイミング(任意)'
     select '外食', from: '食事タイプ(任意)'
     fill_in 'メニュー1(必須)', with: '唐揚げ'
-    fill_in 'meal_form_meal_weight_first', with: 200
-    fill_in 'meal_form_meal_calorie_first', with: 500
+    fill_in 'meal_meal_weight_first', with: 200
+    fill_in 'meal_meal_calorie_first', with: 500
     fill_in 'メニュー2(任意)', with: '唐揚げ'
-    fill_in 'meal_form_meal_weight_second', with: 200
-    fill_in 'meal_form_meal_calorie_second', with: 500
+    fill_in 'meal_meal_weight_second', with: 200
+    fill_in 'meal_meal_calorie_second', with: 500
     fill_in 'メニュー3(任意)', with: '唐揚げ'
-    fill_in 'meal_form_meal_weight_third', with: 200
-    fill_in 'meal_form_meal_calorie_third', with: 500
+    fill_in 'meal_meal_weight_third', with: 200
+    fill_in 'meal_meal_calorie_third', with: 500
     fill_in 'メモ', with: '唐揚げおいしい'
-    attach_file 'meal_form[meal_images][]', "#{Rails.root}/spec/fixtures/images/sample_man.png"
+    attach_file 'meal[meal_images][]', "#{Rails.root}/spec/fixtures/images/sample_man.png"
     click_button '投稿する'
     expect(page).to have_content '食事投稿を作成しました'
     expect(page).to have_selector("img[src$='sample_man.png']")


### PR DESCRIPTION
## 概要
- 食事投稿の編集画面に遷移すると、前回までの入力内容が消えるバグを解消
- 食事投稿の画像も編集時に消えないように修正
- editページで現在保存されている画像が見えるように修正

## 確認方法
- 新規食事投稿、食事投稿編集画面で確認

## 影響範囲
- meal_formを修正したため、mealsリソース全体に影響

## チェックリスト
- [x] Lint のチェックをパスした
- [x] ユニットテストをパスした

## コメント
- 検索機能実行時のバグも要改善
