### PR TITLE
[Fix UI to index transition#123] UIの修正

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -51,9 +51,9 @@ gem 'image_processing', '~> 1.2'
 gem 'cssbundling-rails'
 gem 'enum_help'
 gem 'jsbundling-rails'
+gem 'kaminari'
 gem 'rails-i18n', '~> 7.0.0'
 gem 'sorcery'
-gem 'kaminari'
 
 group :production do
   gem 'aws-sdk-s3', require: false

--- a/app/controllers/meals_controller.rb
+++ b/app/controllers/meals_controller.rb
@@ -38,12 +38,12 @@ class MealsController < ApplicationController
 
   def update
     load_meal
-    
+
     @meal_form = MealForm.new(meal_params, meal: @meal)
     if @meal_form.save
       if params.dig(:meal, :meal_images)[1].present?
         images = ActiveStorage::Attachment.where(record_id: params[:id])
-        images.each {|image| image.purge }
+        images.each(&:purge)
         @meal.meal_images.attach(params[:meal][:meal_images])
       end
       redirect_to user_path(current_user), success: t('defaults.message.updated', item: Meal.model_name.human)

--- a/app/views/meals/index.html.erb
+++ b/app/views/meals/index.html.erb
@@ -1,9 +1,11 @@
 <div class="w-full">
   <div class="m-8">
-    <h1 class="text-xl font-bold"><%= t '.title' %></h1>
-    <%=link_to workouts_path, class: "btn btn-outline m-4" do %>
-      <button><%= (t '.to_workouts_page') %></button>
-    <% end %>
+    <div class="flex items-center">
+      <h1 class="text-xl font-bold"><%= t '.title' %></h1>
+      <%=link_to workouts_path, class: "btn btn-outline m-4" do %>
+        <button><%= (t '.to_workouts_page') %></button>
+      <% end %>
+    </div>
     <div class="flex flex-wrap w-full">
       <% if @meals.present? %>
         <%= render @meals %>

--- a/app/views/shared/_sidebar.html.erb
+++ b/app/views/shared/_sidebar.html.erb
@@ -14,7 +14,7 @@
         <svg xmlns="http://www.w3.org/2000/svg" class="h-5 w-5 m-2" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor">
         <path stroke-linecap="round" stroke-linejoin="round" d="M6 6.878V6a2.25 2.25 0 012.25-2.25h7.5A2.25 2.25 0 0118 6v.878m-12 0c.235-.083.487-.128.75-.128h10.5c.263 0 .515.045.75.128m-12 0A2.25 2.25 0 004.5 9v.878m13.5-3A2.25 2.25 0 0119.5 9v.878m0 0a2.246 2.246 0 00-.75-.128H5.25c-.263 0-.515.045-.75.128m15 0A2.25 2.25 0 0121 12v6a2.25 2.25 0 01-2.25 2.25H5.25A2.25 2.25 0 013 18v-6c0-.98.626-1.813 1.5-2.122" />
         </svg>
-        <label tabindex="0" class="font-bold m-2">タイムライン</label>
+        <label tabindex="0" class="font-bold m-2">投稿一覧</label>
       </div>
       <ul tabindex="0" class="dropdown-content menu p-2 shadow bg-base-100 rounded-box w-52">
         <li><%= link_to '筋トレ投稿一覧', workouts_path %></li>
@@ -46,7 +46,7 @@
     <svg xmlns="http://www.w3.org/2000/svg" class="h-5 w-5" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor">
     <path stroke-linecap="round" stroke-linejoin="round" d="M6 6.878V6a2.25 2.25 0 012.25-2.25h7.5A2.25 2.25 0 0118 6v.878m-12 0c.235-.083.487-.128.75-.128h10.5c.263 0 .515.045.75.128m-12 0A2.25 2.25 0 004.5 9v.878m13.5-3A2.25 2.25 0 0119.5 9v.878m0 0a2.246 2.246 0 00-.75-.128H5.25c-.263 0-.515.045-.75.128m15 0A2.25 2.25 0 0121 12v6a2.25 2.25 0 01-2.25 2.25H5.25A2.25 2.25 0 013 18v-6c0-.98.626-1.813 1.5-2.122" />
     </svg>
-    <span tabindex="0" class="btm-nav-label">タイムライン</span>
+    <span tabindex="0" class="btm-nav-label">投稿一覧</span>
       <ul tabindex="0" class="dropdown-content menu p-2 shadow bg-base-100 rounded-box w-52">
         <li><%= link_to '筋トレ投稿一覧', workouts_path %></li>
         <li><%= link_to '食事投稿一覧', meals_path %></li>

--- a/app/views/shared/_sidebar.html.erb
+++ b/app/views/shared/_sidebar.html.erb
@@ -1,45 +1,66 @@
-<div class="sidebar hidden md:flex md:flex-col md:min-w-max md:p-4 md:bg-base-300 md:w-30 md:drop-shadow-lg md:rounded-md">
-  <nav class="text-center">
-    <ul class="menu">
-      <li><%= link_to 'マイページ', user_path(current_user.id) %><li>
-      <li><%= link_to 'タイムライン', workouts_path %></li>
-    </ul>
-    <div class="menu dropdown dropdown-hover py-4">
-      <label tabindex="0">新規投稿作成</label>
+<div class="sidebar hidden md:flex md:flex-col md:min-w-max md:p-4 md:bg-base-300 md:drop-shadow-lg md:rounded-md z-50">
+  <nav>
+    <div class="py-2">
+      <%= link_to user_path(current_user.id) do %>
+        <div class="to_mypage flex">
+          <svg xmlns="http://www.w3.org/2000/svg" class="h-5 w-5 m-2" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+          <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M3 12l2-2m0 0l7-7 7 7M5 10v10a1 1 0 001 1h3m10-11l2 2m-2-2v10a1 1 0 01-1 1h-3m-6 0a1 1 0 001-1v-4a1 1 0 011-1h2a1 1 0 011 1v4a1 1 0 001 1m-6 0h6" /></svg>
+          <span class="btm-nav-label m-2 font-bold">マイページ</span>
+        </div>
+      <% end %>
+    </div>
+    <div class="menu dropdown dropdown-right py-2">
+      <div class="to-index flex">
+        <svg xmlns="http://www.w3.org/2000/svg" class="h-5 w-5 m-2" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor">
+        <path stroke-linecap="round" stroke-linejoin="round" d="M6 6.878V6a2.25 2.25 0 012.25-2.25h7.5A2.25 2.25 0 0118 6v.878m-12 0c.235-.083.487-.128.75-.128h10.5c.263 0 .515.045.75.128m-12 0A2.25 2.25 0 004.5 9v.878m13.5-3A2.25 2.25 0 0119.5 9v.878m0 0a2.246 2.246 0 00-.75-.128H5.25c-.263 0-.515.045-.75.128m15 0A2.25 2.25 0 0121 12v6a2.25 2.25 0 01-2.25 2.25H5.25A2.25 2.25 0 013 18v-6c0-.98.626-1.813 1.5-2.122" />
+        </svg>
+        <label tabindex="0" class="font-bold m-2">タイムライン</label>
+      </div>
       <ul tabindex="0" class="dropdown-content menu p-2 shadow bg-base-100 rounded-box w-52">
-        <li><%= link_to '筋トレ', new_workout_path %></li>
-        <li><%= link_to '食事', new_meal_path %></li>
+        <li><%= link_to '筋トレ投稿一覧', workouts_path %></li>
+        <li><%= link_to '食事投稿一覧', meals_path %></li>
+      </ul>
+    </div>
+    <div class="menu dropdown dropdown-right py-2">
+      <div class="to-new-post flex">
+        <svg xmlns="http://www.w3.org/2000/svg" class="h-5 w-5 m-2" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" tabindex="0">
+        <path stroke-linecap="round" stroke-linejoin="round" d="M16.862 4.487l1.687-1.688a1.875 1.875 0 112.652 2.652L10.582 16.07a4.5 4.5 0 01-1.897 1.13L6 18l.8-2.685a4.5 4.5 0 011.13-1.897l8.932-8.931zm0 0L19.5 7.125M18 14v4.75A2.25 2.25 0 0115.75 21H5.25A2.25 2.25 0 013 18.75V8.25A2.25 2.25 0 015.25 6H10" />
+        </svg>
+        <label tabindex="0" class="font-bold m-2">新規投稿作成</label>
+      </div>
+      <ul tabindex="0" class="dropdown-content menu p-2 shadow bg-base-100 rounded-box w-52">
+        <li><%= link_to '新規筋トレ投稿', new_workout_path %></li>
+        <li><%= link_to '新規食事投稿', new_meal_path %></li>
       </ul>
     </div>
   </nav>
 </div>
-
 <div class="btm-nav z-50 md:hidden bg-base-300">
   <%= link_to user_path(current_user.id) do %>
-    <button>
+    <div class="flex flex-col items-center">
       <svg xmlns="http://www.w3.org/2000/svg" class="h-5 w-5" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M3 12l2-2m0 0l7-7 7 7M5 10v10a1 1 0 001 1h3m10-11l2 2m-2-2v10a1 1 0 01-1 1h-3m-6 0a1 1 0 001-1v-4a1 1 0 011-1h2a1 1 0 011 1v4a1 1 0 001 1m-6 0h6" /></svg>
       <span class="btm-nav-label">マイページ</span>
-    </button>
-  <% end %>
-  <%= link_to workouts_path do %>
-    <button>
-      <svg xmlns="http://www.w3.org/2000/svg" class="h-5 w-5" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor">
-      <path stroke-linecap="round" stroke-linejoin="round" d="M6 6.878V6a2.25 2.25 0 012.25-2.25h7.5A2.25 2.25 0 0118 6v.878m-12 0c.235-.083.487-.128.75-.128h10.5c.263 0 .515.045.75.128m-12 0A2.25 2.25 0 004.5 9v.878m13.5-3A2.25 2.25 0 0119.5 9v.878m0 0a2.246 2.246 0 00-.75-.128H5.25c-.263 0-.515.045-.75.128m15 0A2.25 2.25 0 0121 12v6a2.25 2.25 0 01-2.25 2.25H5.25A2.25 2.25 0 013 18v-6c0-.98.626-1.813 1.5-2.122" />
-      </svg>
-      <span class="btm-nav-label">タイムライン</span>
-    </button>
-  <% end %>
-  <button>
-    <div class="dropdown dropdown-top dropdown-end">
-      <svg xmlns="http://www.w3.org/2000/svg" class="h-5 w-5" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" tabindex="0">
-      <path stroke-linecap="round" stroke-linejoin="round" d="M16.862 4.487l1.687-1.688a1.875 1.875 0 112.652 2.652L10.582 16.07a4.5 4.5 0 01-1.897 1.13L6 18l.8-2.685a4.5 4.5 0 011.13-1.897l8.932-8.931zm0 0L19.5 7.125M18 14v4.75A2.25 2.25 0 0115.75 21H5.25A2.25 2.25 0 013 18.75V8.25A2.25 2.25 0 015.25 6H10" />
-      </svg>
-      <span tabindex="0" class="btm-nav-label">新規投稿作成</span>
-        <ul tabindex="0" class="dropdown-content menu p-2 shadow bg-base-100 rounded-box w-52">
-          <li><%= link_to '筋トレ', new_workout_path %></li>
-          <li><%= link_to '食事', new_meal_path %></li>
-        </ul>
     </div>
-  </button>
+  <% end %>
+  <div class="flex flex-col items-center dropdown dropdown-top dropdown-end">
+    <svg xmlns="http://www.w3.org/2000/svg" class="h-5 w-5" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor">
+    <path stroke-linecap="round" stroke-linejoin="round" d="M6 6.878V6a2.25 2.25 0 012.25-2.25h7.5A2.25 2.25 0 0118 6v.878m-12 0c.235-.083.487-.128.75-.128h10.5c.263 0 .515.045.75.128m-12 0A2.25 2.25 0 004.5 9v.878m13.5-3A2.25 2.25 0 0119.5 9v.878m0 0a2.246 2.246 0 00-.75-.128H5.25c-.263 0-.515.045-.75.128m15 0A2.25 2.25 0 0121 12v6a2.25 2.25 0 01-2.25 2.25H5.25A2.25 2.25 0 013 18v-6c0-.98.626-1.813 1.5-2.122" />
+    </svg>
+    <span tabindex="0" class="btm-nav-label">タイムライン</span>
+      <ul tabindex="0" class="dropdown-content menu p-2 shadow bg-base-100 rounded-box w-52">
+        <li><%= link_to '筋トレ投稿一覧', workouts_path %></li>
+        <li><%= link_to '食事投稿一覧', meals_path %></li>
+      </ul>
+  </div>
+  <div class="flex flex-col items-center dropdown dropdown-top dropdown-end">
+    <svg xmlns="http://www.w3.org/2000/svg" class="h-5 w-5" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" tabindex="0">
+    <path stroke-linecap="round" stroke-linejoin="round" d="M16.862 4.487l1.687-1.688a1.875 1.875 0 112.652 2.652L10.582 16.07a4.5 4.5 0 01-1.897 1.13L6 18l.8-2.685a4.5 4.5 0 011.13-1.897l8.932-8.931zm0 0L19.5 7.125M18 14v4.75A2.25 2.25 0 0115.75 21H5.25A2.25 2.25 0 013 18.75V8.25A2.25 2.25 0 015.25 6H10" />
+    </svg>
+    <span tabindex="0" class="btm-nav-label">新規投稿作成</span>
+      <ul tabindex="0" class="dropdown-content menu p-2 shadow bg-base-100 rounded-box w-52">
+        <li><%= link_to '新規筋トレ投稿', new_workout_path %></li>
+        <li><%= link_to '新規食事投稿', new_meal_path %></li>
+      </ul>
+  </div>
 </div>
 

--- a/app/views/static_pages/top.html.erb
+++ b/app/views/static_pages/top.html.erb
@@ -4,14 +4,19 @@
       <h1 class="text-5xl font-bold">Bulk Upper</h1>
       <p class="py-8 text-xl">バルクアップしたい人をサポートする<br>筋トレ、食事メニューの記録と共有サービス</p>
       <% unless logged_in? %>
-        <%= link_to '会員登録なしでユーザーの投稿をチェック', workouts_path, class: 'btn'%>
+      <div class="flex flex-col items-center dropdown dropdown-bottom">
+        <button tabindex="0" class="btn btm-nav-label">会員登録なしでユーザーの投稿をチェック</button>
+        <ul tabindex="0" class="dropdown-content menu p-2 bg-base-300 text-base-content shadow rounded-box w-52">
+          <li><%= link_to '筋トレ投稿一覧', workouts_path %></li>
+          <li><%= link_to '食事投稿一覧', meals_path %></li>
+        </ul>
+      </div>
       <% end %>
     </div>
   </div>
   <div class="hero-content text-center my-12">
     <div>
       <h1 class="text-5xl font-bold my-16">How to use</h1>
-
       <div class="hero-content flex-col lg:flex-row">
         <%= image_tag 'step1.jpg', size: "400x260", class:"max-w-sm rounded-lg shadow-2xl" %>
         <div class="p-4">
@@ -20,7 +25,6 @@
           <p>バルクアップに必要な1日に必要な摂取カロリーを自動で計算します</p>
         </div>
       </div>
-
       <div class="hero-content flex-col lg:flex-row-reverse">
         <%= image_tag 'step2.jpg', size: "400x260", class:"max-w-sm rounded-lg shadow-2xl" %>
         <div class="p-4">
@@ -29,7 +33,6 @@
           <p>メニュー名など自由に登録ができます</p>
         </div>
       </div>
-
       <div class="hero-content flex-col lg:flex-row">
         <%= image_tag 'step3.jpg', size: "400x260", class:"max-w-sm rounded-lg shadow-2xl" %>
         <div class="p-4">
@@ -38,7 +41,6 @@
           <p>筋トレメニューの記録や食事メニューの記録を日付ごと確認できます</p>
         </div>
       </div>
-
       <div class="hero-content flex-col lg:flex-row-reverse">
         <%= image_tag 'step4.jpg', size: "400x260", class:"max-w-sm rounded-lg shadow-2xl" %>
         <div class="p-4">

--- a/app/views/workouts/index.html.erb
+++ b/app/views/workouts/index.html.erb
@@ -1,9 +1,11 @@
 <div class="w-full">
   <div class="m-8">
-    <h1 class="text-xl font-bold"><%= t '.title' %></h1>
-    <%=link_to meals_path, class: "btn btn-outline m-4" do %>
-      <button><%= (t '.to_meals_page') %></button>
-    <% end %>
+    <div class="flex items-center">
+      <h1 class="text-xl font-bold"><%= t '.title' %></h1>
+      <%=link_to meals_path, class: "btn btn-outline m-4" do %>
+        <button><%= (t '.to_meals_page') %></button>
+      <% end %>
+    </div>
     <div class="flex flex-wrap w-full">
       <% if @workouts.present? %>
         <%= render @workouts %>

--- a/spec/system/meal_form_spec.rb
+++ b/spec/system/meal_form_spec.rb
@@ -30,8 +30,8 @@ RSpec.describe 'MealForm', js: true do
 
   it '食事タイムラインへボタンをクリックすると食事タイムラインが表示されること' do
     login_as(user)
-    click_on 'タイムライン'
-    click_button '食事投稿一覧へ'
+    page.first('.to-index').click
+    click_on '食事投稿一覧'
     expect(page).to have_content '食事投稿一覧'
     expect(page).to have_current_path meals_path, ignore_query: true
   end

--- a/spec/system/user_sessions_spec.rb
+++ b/spec/system/user_sessions_spec.rb
@@ -42,13 +42,19 @@ RSpec.describe 'UserSessions' do
       it 'ログイン後サイドバーが表示され、マイページへのリンクがあること' do
         login_as(user)
         visit profile_path
-        expect(page).to have_link 'マイページ'
+        expect(page).to have_content 'マイページ'
       end
 
       it 'ログイン後サイドバーが表示され、タイムラインのリンクがあること' do
         login_as(user)
         visit profile_path
-        expect(page).to have_link 'タイムライン'
+        expect(page).to have_content 'タイムライン'
+      end
+
+      it 'ログイン後サイドバーが表示され、新規投稿作成のリンクがあること' do
+        login_as(user)
+        visit profile_path
+        expect(page).to have_content '新規投稿作成'
       end
     end
   end

--- a/spec/system/user_sessions_spec.rb
+++ b/spec/system/user_sessions_spec.rb
@@ -45,10 +45,10 @@ RSpec.describe 'UserSessions' do
         expect(page).to have_content 'マイページ'
       end
 
-      it 'ログイン後サイドバーが表示され、タイムラインのリンクがあること' do
+      it 'ログイン後サイドバーが表示され、投稿一覧のリンクがあること' do
         login_as(user)
         visit profile_path
-        expect(page).to have_content 'タイムライン'
+        expect(page).to have_content '投稿一覧'
       end
 
       it 'ログイン後サイドバーが表示され、新規投稿作成のリンクがあること' do

--- a/spec/system/workouts_spec.rb
+++ b/spec/system/workouts_spec.rb
@@ -23,7 +23,8 @@ RSpec.describe 'Workouts', js: true do
 
   it 'サイドバーのタイムラインをクリックすると筋トレのタイムラインが表示されること' do
     login_as(user)
-    click_on 'タイムライン'
+    page.first('.to-index').click
+    click_on '筋トレ投稿一覧'
     expect(page).to have_content '筋トレ投稿一覧'
     expect(page).to have_current_path workouts_path, ignore_query: true
   end


### PR DESCRIPTION
## 概要
- タイムラインから、各投稿一覧へ名称修正
- ドロップダウンメニューから筋トレ投稿、食事投稿を両方見れるようにした

## 確認方法
- ログイン前後のメニュー表示をブラウザで確認

## 影響範囲
- 一覧ページへのリンクを貼っている箇所に影響

## チェックリスト
- [x] Lint のチェックをパスした
- [x] テストをパスした

## コメント
- ユーザーの意見を聞きながらUIは適宜修正
close #123 
