### PR TITLE
[bug_fix#125] トップページボタンのHTML, class修正

### DIFF
--- a/app/views/static_pages/top.html.erb
+++ b/app/views/static_pages/top.html.erb
@@ -5,7 +5,7 @@
       <p class="py-8 text-xl">バルクアップしたい人をサポートする<br>筋トレ、食事メニューの記録と共有サービス</p>
       <% unless logged_in? %>
       <div class="flex flex-col items-center dropdown dropdown-bottom">
-        <button tabindex="0" class="btn btm-nav-label">会員登録なしでユーザーの投稿をチェック</button>
+        <label tabindex="0" class="btn">会員登録なしでユーザーの投稿をチェック</label>
         <ul tabindex="0" class="dropdown-content menu p-2 bg-base-300 text-base-content shadow rounded-box w-52">
           <li><%= link_to '筋トレ投稿一覧', workouts_path %></li>
           <li><%= link_to '食事投稿一覧', meals_path %></li>


### PR DESCRIPTION
## 概要
- ログイン前のユーザーのみ表示されるトップページの一覧画面への誘導ボタンで、スマホではドロップダウンメニューが表示されないバグの修正

## 確認方法
- スマホのブラウザからログイン前トップページを開いて確認してください

## 影響範囲
トップページのビューのみ

## チェックリスト
- [x] Lint のチェックをパスした
- [x] ユニットテストをパスした

## コメント
- バグの根本的な原因は不明だが、buttonタグではなくlabelタグへの修正したことでうまくいった。
close #125 
