### PR TITLE
[fix_target_carolie_calc_logic#128] target_calorieの計算ロジック修正

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -38,7 +38,7 @@ class User < ApplicationRecord
       else
         ((9.247 * body_weight) + (3.098 * height) - (4.33 * age) + 447.593) * @active_level_coefficient
       end
-    self.target_calorie = maintenance_calorie + adjustment_calorie
+    self.target_calorie = maintenance_calorie + adjustment_calorie + 300
     save
   end
 


### PR DESCRIPTION
## 概要
- target_calorieの計算ロジック修正 （メンテナンスカロリー+300kal）

## 確認方法
- プロフィール更新時に確認

## 影響範囲
userリソースのtarget_calorieを用いる部分

## チェックリスト
- [x] Lint のチェックをパスした
- [x] ユニットテストをパスした

## コメント
- ユーザーの反応をみながら適宜修正
close #128 