### PR TITLE
[Add sitemap generator#139]サイトマップの作成

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -42,3 +42,6 @@ vendor/bundle
 
 # Ignore precompiled javascript packs
 /public/dev-assets
+
+# Ignore sitemaps of develpment environment
+/public/sitemap.xml.gz

--- a/Gemfile
+++ b/Gemfile
@@ -54,6 +54,7 @@ gem 'jsbundling-rails'
 gem 'kaminari'
 gem 'rails-i18n', '~> 7.0.0'
 gem 'sorcery'
+gem 'sitemap_generator'
 
 group :production do
   gem 'aws-sdk-s3', require: false

--- a/Gemfile
+++ b/Gemfile
@@ -53,8 +53,8 @@ gem 'enum_help'
 gem 'jsbundling-rails'
 gem 'kaminari'
 gem 'rails-i18n', '~> 7.0.0'
-gem 'sorcery'
 gem 'sitemap_generator'
+gem 'sorcery'
 
 group :production do
   gem 'aws-sdk-s3', require: false

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -291,6 +291,8 @@ GEM
       rexml (~> 3.2, >= 3.2.5)
       rubyzip (>= 1.2.2, < 3.0)
       websocket (~> 1.0)
+    sitemap_generator (6.3.0)
+      builder (~> 3.0)
     snaky_hash (2.0.1)
       hashie
       version_gem (~> 1.1, >= 1.1.1)
@@ -362,6 +364,7 @@ DEPENDENCIES
   rubocop-performance
   rubocop-rails
   rubocop-rspec
+  sitemap_generator
   sorcery
   sprockets-rails
   stimulus-rails

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -13,4 +13,5 @@ Rails.application.routes.draw do
   resources :meals
   get 'calorie_search', to: 'meals#calorie_search'
   get 'date_search', to: 'users#date_search'
+  get '/sitemap', to: redirect("https://s3-ap-northeast-1.amazonaws.com/#{Rails.application.credentials.aws[:s3][:bucket]}/sitemaps/sitemap.xml.gz")
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -13,5 +13,5 @@ Rails.application.routes.draw do
   resources :meals
   get 'calorie_search', to: 'meals#calorie_search'
   get 'date_search', to: 'users#date_search'
-  get '/sitemap', to: redirect("https://s3-ap-northeast-1.amazonaws.com/#{Rails.application.credentials.aws[:s3][:bucket]}/sitemaps/sitemap.xml.gz")
+  get 'sitemap', to: redirect("https://s3-ap-northeast-1.amazonaws.com/#{Rails.application.credentials.aws[:s3][:bucket]}/sitemaps/sitemap.xml.gz")
 end

--- a/config/sitemap.rb
+++ b/config/sitemap.rb
@@ -1,3 +1,5 @@
+require 'aws-sdk-s3'
+
 SitemapGenerator::Sitemap.default_host = "https://bulk-upper.com/"
 SitemapGenerator::Sitemap.sitemaps_host = "https://s3-ap-northeast-1.amazonaws.com/#{Rails.application.credentials.aws[:s3][:bucket]}"
 SitemapGenerator::Sitemap.adapter = SitemapGenerator::AwsSdkAdapter.new(

--- a/config/sitemap.rb
+++ b/config/sitemap.rb
@@ -2,6 +2,7 @@ require 'aws-sdk-s3'
 
 SitemapGenerator::Sitemap.default_host = "https://bulk-upper.com/"
 SitemapGenerator::Sitemap.sitemaps_host = "https://s3-ap-northeast-1.amazonaws.com/#{Rails.application.credentials.aws[:s3][:bucket]}"
+SitemapGenerator::Sitemap.sitemaps_path = 'sitemaps/'
 SitemapGenerator::Sitemap.adapter = SitemapGenerator::AwsSdkAdapter.new(
   Rails.application.credentials.aws[:s3][:bucket],
   aws_access_key_id: Rails.application.credentials.aws[:access_key_id],

--- a/config/sitemap.rb
+++ b/config/sitemap.rb
@@ -1,0 +1,38 @@
+SitemapGenerator::Sitemap.default_host = "https://bulk-upper.com/"
+SitemapGenerator::Sitemap.sitemaps_host = "https://s3-ap-northeast-1.amazonaws.com/#{Rails.application.credentials.aws[:s3][:bucket]}"
+SitemapGenerator::Sitemap.adapter = SitemapGenerator::AwsSdkAdapter.new(
+  Rails.application.credentials.aws[:s3][:bucket],
+  aws_access_key_id: Rails.application.credentials.aws[:access_key_id],
+  aws_secret_access_key: Rails.application.credentials.aws[:secret_access_key],
+  aws_region: Rails.application.credentials.aws[:s3][:region]
+)
+SitemapGenerator::Sitemap.create do
+  # Defaults: :priority => 0.5, :changefreq => 'weekly',
+  #           :lastmod => Time.now, :host => default_host
+  # 利用規約
+  add terms_path
+  # プライバシーポリシー
+  add privacy_path
+  # 問い合わせ
+  add contact_path
+  # ログインページ
+  add login_path
+  # ユーザー登録ページ
+  add new_user_path
+  # ユーザー詳細ページ（マイページ）
+  User.find_each do |user|
+    add user_path(user), :priority => 0.7, :changefreq => 'daily'
+  end
+  # 筋トレ投稿一覧
+  add workouts_path, :priority => 0.7, :changefreq => 'daily'
+  # 筋トレ投稿詳細ページ
+  Workout.find_each do |workout|
+    add workout_path(workout), :priority => 0.7, :lastmod => workout.updated_at
+  end
+  # 食事投稿一覧
+  add meals_path, :priority => 0.7, :changefreq => 'daily'
+  # 食事投稿詳細ページ
+  Meal.find_each do |meal|
+    add meal_path(meal), :priority => 0.7, :lastmod => meal.updated_at
+  end
+end

--- a/lib/tasks/scheduler.rake
+++ b/lib/tasks/scheduler.rake
@@ -3,7 +3,3 @@ task :test_scheduler => :environment do
   puts 'scheduler test'
   puts 'it works.'
 end
-
-task :create_sitemaps => :environment do
-  rake 'sitemap:refresh'
-end

--- a/lib/tasks/scheduler.rake
+++ b/lib/tasks/scheduler.rake
@@ -1,0 +1,9 @@
+desc "This task is called by the Heroku scheduler add-on"
+task :test_scheduler => :environment do
+  puts 'scheduler test'
+  puts 'it works.'
+end
+
+task :create_sitemaps => :environment do
+  rake 'sitemap:refresh'
+end

--- a/lib/tasks/scheduler.rake
+++ b/lib/tasks/scheduler.rake
@@ -1,5 +1,5 @@
-desc "This task is called by the Heroku scheduler add-on"
-task :test_scheduler => :environment do
+desc 'This task is called by the Heroku scheduler add-on'
+task test_scheduler: :environment do
   puts 'scheduler test'
   puts 'it works.'
 end

--- a/public/robots.txt
+++ b/public/robots.txt
@@ -1,1 +1,2 @@
 # See https://www.robotstxt.org/robotstxt.html for documentation on how to use the robots.txt file
+Sitemap: https://bulk-upper.com/sitemap


### PR DESCRIPTION
## 概要
- `sitemap_generator` gemを使って、サイトマップを作成する

## 確認方法
- `https://bulk-upper.com/sitemap`にアクセスしてサイトマップがダウンロードできること

## 影響範囲
特になし。

## チェックリスト
- [x] Lint のチェックをパスした
- [x] テストをパスした

## コメント
- herokuスケジューラーに`rake sitemap:refresh`を追加
- rakeタスクの定義ファイルは後日削除
#139 
