### PR TITLE
[Add admin#133]　管理画面の追加

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -57,6 +57,8 @@ gem 'rails-i18n', '~> 7.0.0'
 gem 'sitemap_generator'
 gem 'sorcery'
 gem 'rails_admin', '~> 3.0'
+gem "sassc-rails"
+gem 'cancancan'
 
 group :production do
   gem 'aws-sdk-s3', require: false
@@ -89,4 +91,3 @@ group :test do
   gem 'capybara'
   gem 'webdrivers'
 end
-gem "sassc-rails"

--- a/Gemfile
+++ b/Gemfile
@@ -56,6 +56,7 @@ gem 'meta-tags'
 gem 'rails-i18n', '~> 7.0.0'
 gem 'sitemap_generator'
 gem 'sorcery'
+gem 'rails_admin', '~> 3.0'
 
 group :production do
   gem 'aws-sdk-s3', require: false

--- a/Gemfile
+++ b/Gemfile
@@ -48,17 +48,17 @@ gem 'bootsnap', require: false
 # Use Active Storage variants [https://guides.rubyonrails.org/active_storage_overview.html#transforming-images]
 gem 'image_processing', '~> 1.2'
 
+gem 'cancancan'
 gem 'cssbundling-rails'
 gem 'enum_help'
 gem 'jsbundling-rails'
 gem 'kaminari'
 gem 'meta-tags'
+gem 'rails_admin', '~> 3.0'
 gem 'rails-i18n', '~> 7.0.0'
+gem 'sassc-rails'
 gem 'sitemap_generator'
 gem 'sorcery'
-gem 'rails_admin', '~> 3.0'
-gem "sassc-rails"
-gem 'cancancan'
 
 group :production do
   gem 'aws-sdk-s3', require: false

--- a/Gemfile
+++ b/Gemfile
@@ -89,3 +89,4 @@ group :test do
   gem 'capybara'
   gem 'webdrivers'
 end
+gem "sassc-rails"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -94,6 +94,7 @@ GEM
     bootsnap (1.15.0)
       msgpack (~> 1.2)
     builder (3.2.4)
+    cancancan (3.4.0)
     capybara (3.38.0)
       addressable
       matrix
@@ -365,6 +366,7 @@ PLATFORMS
 DEPENDENCIES
   aws-sdk-s3
   bootsnap
+  cancancan
   capybara
   cssbundling-rails
   debug

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -300,6 +300,14 @@ GEM
       ffi (~> 1.12)
     ruby2_keywords (0.0.5)
     rubyzip (2.3.2)
+    sassc (2.4.0)
+      ffi (~> 1.9)
+    sassc-rails (2.1.2)
+      railties (>= 4.0.0)
+      sassc (>= 2.0)
+      sprockets (> 3.0)
+      sprockets-rails
+      tilt
     selenium-webdriver (4.7.1)
       rexml (~> 3.2, >= 3.2.5)
       rubyzip (>= 1.2.2, < 3.0)
@@ -323,6 +331,7 @@ GEM
     stimulus-rails (1.2.1)
       railties (>= 6.0.0)
     thor (1.2.1)
+    tilt (2.0.11)
     timeout (0.3.1)
     turbo-rails (1.3.2)
       actionpack (>= 6.0.0)
@@ -379,6 +388,7 @@ DEPENDENCIES
   rubocop-performance
   rubocop-rails
   rubocop-rspec
+  sassc-rails
   sitemap_generator
   sorcery
   sprockets-rails

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -51,6 +51,10 @@ GEM
       globalid (>= 0.3.6)
     activemodel (7.0.4)
       activesupport (= 7.0.4)
+    activemodel-serializers-xml (1.0.2)
+      activemodel (> 5.x)
+      activesupport (> 5.x)
+      builder (~> 3.1)
     activerecord (7.0.4)
       activemodel (= 7.0.4)
       activesupport (= 7.0.4)
@@ -175,6 +179,7 @@ GEM
     minitest (5.16.3)
     msgpack (1.6.0)
     multi_xml (0.6.0)
+    nested_form (0.3.2)
     net-imap (0.3.4)
       date
       net-protocol
@@ -232,6 +237,12 @@ GEM
     rails-i18n (7.0.6)
       i18n (>= 0.7, < 2)
       railties (>= 6.0.0, < 8)
+    rails_admin (3.1.1)
+      activemodel-serializers-xml (>= 1.0)
+      kaminari (>= 0.14, < 2.0)
+      nested_form (~> 0.3)
+      rails (>= 6.0, < 8)
+      turbo-rails (~> 1.0)
     railties (7.0.4)
       actionpack (= 7.0.4)
       activesupport (= 7.0.4)
@@ -361,6 +372,7 @@ DEPENDENCIES
   puma (~> 5.0)
   rails (~> 7.0.4)
   rails-i18n (~> 7.0.0)
+  rails_admin (~> 3.0)
   redis (~> 4.0)
   rspec-rails
   rubocop

--- a/app/assets/config/manifest.js
+++ b/app/assets/config/manifest.js
@@ -1,2 +1,3 @@
 //= link_tree ../images
 //= link_tree ../builds
+//= link application.css

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -7,7 +7,7 @@ class ApplicationController < ActionController::Base
   # ログイン済みユーザーかどうか確認(:require_loginのメソッドに追加)
   def not_authenticated
     flash[:warning] = t('defaults.message.require_login')
-    redirect_to main_app.login_path #rails_admin
+    redirect_to main_app.login_path # rails_admin
   end
 
   rescue_from CanCan::AccessDenied do |exception|

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -9,4 +9,8 @@ class ApplicationController < ActionController::Base
     flash[:warning] = t('defaults.message.require_login')
     redirect_to main_app.login_path #rails_admin
   end
+
+  rescue_from CanCan::AccessDenied do |exception|
+    redirect_to main_app.root_path, alert: exception.message
+  end
 end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -7,6 +7,6 @@ class ApplicationController < ActionController::Base
   # ログイン済みユーザーかどうか確認(:require_loginのメソッドに追加)
   def not_authenticated
     flash[:warning] = t('defaults.message.require_login')
-    redirect_to login_path
+    redirect_to main_app.login_path #rails_admin
   end
 end

--- a/app/models/ability.rb
+++ b/app/models/ability.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+class Ability
+  include CanCan::Ability
+
+  def initialize(user)
+    return unless user && user&.admin?
+
+    can :access, :rails_admin
+    can :manage, :all
+  end
+end

--- a/app/models/ability.rb
+++ b/app/models/ability.rb
@@ -4,7 +4,7 @@ class Ability
   include CanCan::Ability
 
   def initialize(user)
-    return unless user && user&.admin?
+    return unless user&.admin?
 
     can :access, :rails_admin
     can :manage, :all

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -26,6 +26,7 @@ class User < ApplicationRecord
 
   enum sex: { male: 0, female: 1 }
   enum active_level: { level1: 1, level2: 2, level3: 3, level4: 4, level5: 5 }
+  enum role: { general: 0, admin: 1 }
 
   def own?(object)
     object.user_id == id

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -56,5 +56,8 @@ Rails.application.configure do
   # config.i18n.raise_on_missing_translations = true
 
   # Annotate rendered view with file names.
-  # config.action_view.annotate_rendered_view_with_filenames = true
+  # config.action_view.annotate_rendered_view_with_filenames = 
+
+  # Set a css_compressor so sassc-rails does not overwrite the compressor when running the tests
+  config.assets.css_compressor = nil
 end

--- a/config/initializers/rails_admin.rb
+++ b/config/initializers/rails_admin.rb
@@ -10,9 +10,9 @@ RailsAdmin.config do |config|
   end
   config.current_user_method(&:current_user)
   config.parent_controller = 'ApplicationController'
-  
+
   ## == CancanCan ==
-  # config.authorize_with :cancancan
+  config.authorize_with :cancancan
 
   ## == Pundit ==
   # config.authorize_with :pundit

--- a/config/initializers/rails_admin.rb
+++ b/config/initializers/rails_admin.rb
@@ -1,0 +1,44 @@
+RailsAdmin.config do |config|
+  config.asset_source = :sprockets
+
+  ### Popular gems integration
+
+  ## == Sorcery ==
+  config.authenticate_with do
+    # Use sorcery's before filter to auth users
+    require_login
+  end
+  config.current_user_method(&:current_user)
+  config.parent_controller = 'ApplicationController'
+  
+  ## == CancanCan ==
+  # config.authorize_with :cancancan
+
+  ## == Pundit ==
+  # config.authorize_with :pundit
+
+  ## == PaperTrail ==
+  # config.audit_with :paper_trail, 'User', 'PaperTrail::Version' # PaperTrail >= 3.0.0
+
+  ### More at https://github.com/railsadminteam/rails_admin/wiki/Base-configuration
+
+  ## == Gravatar integration ==
+  ## To disable Gravatar integration in Navigation Bar set to false
+  # config.show_gravatar = true
+
+  config.actions do
+    dashboard                     # mandatory
+    index                         # mandatory
+    new
+    export
+    bulk_delete
+    show
+    edit
+    delete
+    show_in_app
+
+    ## With an audit adapter, you can add:
+    # history_index
+    # history_show
+  end
+end

--- a/config/locales/views/rails_admin_ja.yml
+++ b/config/locales/views/rails_admin_ja.yml
@@ -1,0 +1,158 @@
+ja:
+  admin:
+    js:
+      true: True
+      false: False
+      is_present: 存在する
+      is_blank: 空白
+      date: 日付 ...
+      between_and_: ... から ...
+      today: 今日
+      yesterday: 昨日
+      this_week: 今週
+      last_week: 先週
+      time: 時刻 ...
+      number: 数字 ...
+      contains: 含む
+      does_not_contain: 含まない
+      is_exactly: 完全に一致
+      starts_with: で始まる
+      ends_with: で終わる
+      too_many_objects: "対象が多すぎます、上の検索ボックスを使用してください"
+      no_objects: "対象が見つかりません"
+      clear: クリア
+    loading: "読み込み中..."
+    toggle_navigation: ナビゲーション切り替え
+    home:
+      name: "ホーム"
+    pagination:
+      previous: "&laquo; 前"
+      next: "次 &raquo;"
+      truncate: "…"
+    misc:
+      search: "検索"
+      filter: "検索"
+      reset_filters: "リセット"
+      refresh: "更新"
+      show_all: "すべて表示"
+      add_filter: "絞り込む..."
+      bulk_menu_title: "選択項目を..."
+      remove: "削除"
+      add_new: "新規作成"
+      chosen: "選択された%{name}"
+      chose_all: "すべて選択"
+      clear_all: "選択解除"
+      up: "上"
+      down: "下"
+      navigation: "ナビゲーション"
+      root_navigation: "アクション"
+      navigation_static_label: "リンク"
+      log_out: "ログアウト"
+      time_ago: "%{time}前"
+      ago: "前"
+      more: "さらに %{count} 個以上の %{models_name}"
+    flash:
+      successful: "%{name}の%{action}に成功しました"
+      error: "%{name}の%{action}に失敗しました"
+      noaction: "操作を取り消しました"
+      model_not_found: "モデル'%{model}'はありません"
+      object_not_found: "'ID:%{id}'の%{model}はありません"
+    table_headers:
+      model_name: "モデル名"
+      last_used: "最終アクセス日"
+      records: "レコード数"
+      username: "ユーザ"
+      changes: "変更"
+      created_at: "日時"
+      item: "アイテム"
+      message: "メッセージ"
+    actions:
+      dashboard:
+        title: "サイト管理"
+        menu: "ダッシュボード"
+        breadcrumb: "ダッシュボード"
+      index:
+        title: "%{model_label_plural}の一覧"
+        menu: "一覧"
+        breadcrumb: "%{model_label_plural}"
+        no_records: "レコードがありません"
+      show:
+        title: "%{model_label} '%{object_label}'の詳細"
+        menu: "詳細"
+        breadcrumb: "%{object_label}"
+      show_in_app:
+        menu: "表示"
+      new:
+        title: "新規%{model_label}"
+        menu: "新規作成"
+        breadcrumb: "新規"
+        link: "新規%{model_label}追加"
+        done: "作成"
+      edit:
+        title: "%{model_label} '%{object_label}'を編集"
+        menu: "編集"
+        breadcrumb: "編集"
+        link: "この%{model_label}を編集"
+        done: "更新"
+      delete:
+        title: "%{model_label} '%{object_label}'を削除"
+        menu: "削除"
+        breadcrumb: "削除"
+        link: "'%{object_label}'削除"
+        done: "削除"
+      bulk_delete:
+        title: "%{model_label_plural}を一括削除"
+        menu: "一括削除"
+        breadcrumb: "一括削除"
+        bulk_link: "選択した%{model_label_plural}を削除"
+      export:
+        title: "%{model_label}をエクスポート"
+        menu: "エクスポート"
+        breadcrumb: "エクスポート"
+        link: "%{model_label_plural}をエクスポート"
+        bulk_link: "選択した%{model_label_plural}をエクスポート"
+        done: "エクスポート"
+      history_index:
+        title: "%{model_label_plural}の更新履歴"
+        menu: "履歴"
+        breadcrumb: "履歴"
+      history_show:
+        title: "%{model_label} '%{object_label}'の履歴"
+        menu: "履歴"
+        breadcrumb: "履歴"
+    form:
+      cancel: "キャンセル"
+      basic_info: "基本情報"
+      required: "必須"
+      optional: "オプション"
+      one_char: "文字"
+      char_length_up_to: "最大文字数:"
+      char_length_of: "文字数:"
+      save: "保存"
+      save_and_add_another: "保存して次へ"
+      save_and_edit: "保存して編集"
+      all_of_the_following_related_items_will_be_deleted: "を削除してよろしいですか? 以下の項目が削除され、もしくは関係を失います:"
+      are_you_sure_you_want_to_delete_the_object: "%{model_name}の項目"
+      confirmation: "実行する"
+      bulk_delete: "以下の項目が削除され、それによって関連する項目が削除され、もしくは関係を失います:"
+      new_model: "%{name} (新規)"
+    export:
+      confirmation: "%{name}としてエクスポート"
+      select: "エクスポートするフィールドを選択してください"
+      select_all_fields: "全フィールドを選択"
+      fields_from: "%{name}のフィールド"
+      fields_from_associated: "関連する%{name}のフィールド"
+      display: "カラム:%{name} 型:%{type}"
+      options_for: "%{name}の出力オプション"
+      empty_value_for_associated_objects: "<empty>"
+      click_to_reverse_selection: "クリックで選択を反転します"
+      csv:
+        header_for_root_methods: "%{name}" # 'model' is available
+        header_for_association_methods: "%{name} [%{association}]"
+        encoding_to: "文字コード"
+        encoding_to_help: "空白の場合は%{name}になります"
+        skip_header: "ヘッダなし"
+        skip_header_help: "チェックすると出力にヘッダ行を含めません"
+        default_col_sep: ","
+        col_sep: "区切り文字"
+        col_sep_help: "空白の場合は'%{value}'区切りです" # value is default_col_sep

--- a/config/locales/views/rails_admin_ja.yml
+++ b/config/locales/views/rails_admin_ja.yml
@@ -136,6 +136,7 @@ ja:
       confirmation: "実行する"
       bulk_delete: "以下の項目が削除され、それによって関連する項目が削除され、もしくは関係を失います:"
       new_model: "%{name} (新規)"
+      delete_file: "ファイル削除"
     export:
       confirmation: "%{name}としてエクスポート"
       select: "エクスポートするフィールドを選択してください"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,4 +1,5 @@
 Rails.application.routes.draw do
+  mount RailsAdmin::Engine => '/admin', as: 'rails_admin'
   root to: 'static_pages#top'
   get 'privacy', to: 'static_pages#privacy'
   get 'terms', to: 'static_pages#terms'

--- a/db/migrate/20230129114114_add_role_to_users.rb
+++ b/db/migrate/20230129114114_add_role_to_users.rb
@@ -1,0 +1,5 @@
+class AddRoleToUsers < ActiveRecord::Migration[7.0]
+  def change
+    add_column :users, :role, :integer, null: false, default: 0
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2022_12_25_032543) do
+ActiveRecord::Schema[7.0].define(version: 2023_01_29_114114) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
   enable_extension "plpgsql"
@@ -91,6 +91,7 @@ ActiveRecord::Schema[7.0].define(version: 2022_12_25_032543) do
     t.string "twitter_link"
     t.string "facebook_link"
     t.string "instagram_link"
+    t.integer "role", default: 0, null: false
     t.index ["email"], name: "index_users_on_email", unique: true
   end
 


### PR DESCRIPTION
## 概要
- `rails_admin` gemを用いて管理画面を実装
- Userモデルにroleカラム(integer, enum)を追加
- `cancancan` gemにて管理画面にアクセスできるユーザーを制限

## 確認方法

1. Gem を追加したので `bundle install` を実行
2. カラムを追加したので `bin/rails db:migrate` を実行
3. 管理者権限ユーザーが管理画面へ遷移できることを確認

## 影響範囲
Usersリソース

## チェックリスト
- [x] Lint のチェックをパスした
- [x] テストをパスした

## コメント
- `bin/rails g rails_admin:install`実行後、`sassc-rails` gemをインストールした
close #133 
