### PR TITLE
[production_env_debug#148] 本番環境の設定ファイルにcss_compressor不使用の記述追加

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -90,4 +90,6 @@ Rails.application.configure do
 
   # Do not dump schema after migrations.
   config.active_record.dump_schema_after_migration = false
+  # To prevent sprockets of using sass mode and SassC gem (which based on deprecated LibSass library) in assets:precompile step
+  config.assets.css_compressor = nil
 end


### PR DESCRIPTION
## 概要
- `rails_admin`と`sassc-rails`を導入したことで、本番環境でコンパイルエラーを起こしていた模様
-` config/environments/production.rb`に`config.assets.css_compressor = nil`を入れることで解決
(参考)
https://github.com/tailwindlabs/tailwindcss/discussions/6738


## コメント
- TailwindでコンパイルされたCSSが何らかの理由でSassに再度送られてしまったため、`sassc-rails` gemによるコンパイルはさせないように設定する必要があるのではないか。
close #148 