### PR TITLE
[Fix name and email#83] ユーザー名とemailの変更機能、マイページのビュー修正

### DIFF
--- a/app/views/profiles/edit.html.erb
+++ b/app/views/profiles/edit.html.erb
@@ -3,38 +3,27 @@
   <h1 class="text-xl font-bold"><%= t '.title' %></h1>
   <%= form_with model: @user, url: profile_path, local: true do |f| %>
   <%= render 'shared/error_messages', object: f.object %>
-
-    <h2 class="text-xl pt-4 font-bold">名前</h2>
-    <p class="py-2"><%= @user.name %></p>
-
-    <h2 class="text-xl pt-4 font-bold">メールアドレス</h2>
-    <p class="py-2"><%= @user.email %></p>
-
     <div class="form-control">
+      <%= f.label :name, class: "text-xl pt-4 font-bold" %>
+      <%= f.text_field :name, class: "input input-bordered" %>
+      <%= f.label :email, class: "text-xl pt-4 font-bold" %>
+      <%= f.email_field :email, class: "input input-bordered" %>
       <%= f.label :introduction, class: "text-xl pt-4 font-bold" %>
       <%= f.text_area :introduction, class: "textarea textarea-bordered" %>
-
       <%= f.label :twitter_link, class: "text-xl pt-4 font-bold" %>
       <%= f.url_field :twitter_link, class: "input input-bordered" %>
-
       <%= f.label :facebook_link, class: "text-xl pt-4 font-bold" %>
       <%= f.url_field :facebook_link, class: "input input-bordered" %>
-
       <%= f.label :instagram_link, class: "text-xl pt-4 font-bold" %>
       <%= f.url_field :instagram_link, class: "input input-bordered" %>
-
       <%= f.label :height, class: "text-xl pt-4 font-bold" %>
       <%= f.number_field :height, class: "input input-bordered" %>
-
       <%= f.label :body_weight, class: "text-xl pt-4 font-bold" %>
       <%= f.number_field :body_weight, class: "input input-bordered" %>
-
       <%= f.label :age, class: "text-xl pt-4 font-bold" %>
       <%= f.number_field :age, class: "form-control input input-bordered" %>
-
       <%= f.label :sex, class: "text-xl pt-4 font-bold" %>
       <%= f.select :sex, User.sexes_i18n.invert.map{|key, value| [key, value]}, {}, class: "select select-bordered w-ful" %>
-
       <%= f.label :active_level, class: "text-xl pt-4 font-bold" %>
       <%= f.select :active_level, User.active_levels_i18n.invert.map{|key, value| [key, value]}, {}, class: "select select-bordered w-ful" %>
       <div class="overflow-x-auto p-4">
@@ -78,17 +67,13 @@
       </div>
       <%= f.label :target_weight, class: "text-xl pt-4 font-bold" %>
       <%= f.number_field :target_weight, class: "form-control input input-bordered" %>
-
       <%= f.label :target_date, class: "text-xl pt-4 font-bold" %>
       <%= f.date_field :target_date, class: "form-control input input-bordered" %>
-
       <%= f.label :adjustment_calorie ,class: "text-xl pt-4 font-bold"%>
       <p>※ここで摂取カロリーを調整できます。<br>体の変化の様子を見ながら、自動計算の目標カロリーの過不足を調整してください<br>（例）目標カロリーでは増量できないので500kcal追加したい場合など</p>
       <%= f.number_field :adjustment_calorie, class: "form-control input input-bordered" %>
-
       <%= f.label :avatar, class: "text-xl pt-4 font-bold" %>
       <%= f.file_field :avatar %>
-
       <%= f.submit '更新する', class: "btn btn-primary my-4"%>
     </div>
     <% end %>

--- a/app/views/profiles/edit.html.erb
+++ b/app/views/profiles/edit.html.erb
@@ -29,7 +29,7 @@
       <div class="overflow-x-auto p-4">
         <table class="table w-full">
           <!-- head -->
-          <h1>※活動量は以下の表を目安に設定してください</h1>
+          <h2>※活動量は以下の表を目安に設定してください</h2>
           <thead>
             <tr>
               <th>活動レベル</th>

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -31,13 +31,33 @@
       <div>
         <div class="p-2">
           <h2 class="font-bold text-lg">自己紹介</h2>
-          <p><%= @user.introduction %><p>
+          <% if @user.introduction.empty? %>
+            <p>未設定</p>
+          <% end %>
+          <p><%= @user.introduction %></p>
         </div>
         <div class="p-2">
           <h2 class="font-bold text-lg">SNS</h2>
-          <p><%= @user.twitter_link if @user.twitter_link.present? %><p>
-          <p><%= @user.instagram_link if @user.instagram_link.present? %><p>
-          <p><%= @user.facebook_link if @user.facebook_link.present? %><p>
+          <div class="flex">
+            <% if @user.twitter_link.empty? && @user.instagram_link && @user.facebook_link%>
+              <p>未設定</p>
+            <% end %>
+            <% if @user.twitter_link.present? %>
+              <%= link_to "#{@user.twitter_link}" do %>
+              <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512" class="w-5 h-5 mx-2"><!--! Font Awesome Pro 6.0.0 by @fontawesome - https://fontawesome.com License - https://fontawesome.com/license (Commercial License) Copyright 2022 Fonticons, Inc. --><path fill="currentColor" d="M459.37 151.716c.325 4.548.325 9.097.325 13.645 0 138.72-105.583 298.558-298.558 298.558-59.452 0-114.68-17.219-161.137-47.106 8.447.974 16.568 1.299 25.34 1.299 49.055 0 94.213-16.568 130.274-44.832-46.132-.975-84.792-31.188-98.112-72.772 6.498.974 12.995 1.624 19.818 1.624 9.421 0 18.843-1.3 27.614-3.573-48.081-9.747-84.143-51.98-84.143-102.985v-1.299c13.969 7.797 30.214 12.67 47.431 13.319-28.264-18.843-46.781-51.005-46.781-87.391 0-19.492 5.197-37.36 14.294-52.954 51.655 63.675 129.3 105.258 216.365 109.807-1.624-7.797-2.599-15.918-2.599-24.04 0-57.828 46.782-104.934 104.934-104.934 30.213 0 57.502 12.67 76.67 33.137 23.715-4.548 46.456-13.32 66.599-25.34-7.798 24.366-24.366 44.833-46.132 57.827 21.117-2.273 41.584-8.122 60.426-16.243-14.292 20.791-32.161 39.308-52.628 54.253z"/></svg>
+              <% end %>
+            <% end %>
+            <% if @user.instagram_link.present? %>
+              <%= link_to "#{@user.instagram_link}" do %>
+              <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 448 512" class="w-5 h-5 mx-2"><!--! Font Awesome Pro 6.0.0 by @fontawesome - https://fontawesome.com License - https://fontawesome.com/license (Commercial License) Copyright 2022 Fonticons, Inc. --><path fill="currentColor" d="M224.1 141c-63.6 0-114.9 51.3-114.9 114.9s51.3 114.9 114.9 114.9S339 319.5 339 255.9 287.7 141 224.1 141zm0 189.6c-41.1 0-74.7-33.5-74.7-74.7s33.5-74.7 74.7-74.7 74.7 33.5 74.7 74.7-33.6 74.7-74.7 74.7zm146.4-194.3c0 14.9-12 26.8-26.8 26.8-14.9 0-26.8-12-26.8-26.8s12-26.8 26.8-26.8 26.8 12 26.8 26.8zm76.1 27.2c-1.7-35.9-9.9-67.7-36.2-93.9-26.2-26.2-58-34.4-93.9-36.2-37-2.1-147.9-2.1-184.9 0-35.8 1.7-67.6 9.9-93.9 36.1s-34.4 58-36.2 93.9c-2.1 37-2.1 147.9 0 184.9 1.7 35.9 9.9 67.7 36.2 93.9s58 34.4 93.9 36.2c37 2.1 147.9 2.1 184.9 0 35.9-1.7 67.7-9.9 93.9-36.2 26.2-26.2 34.4-58 36.2-93.9 2.1-37 2.1-147.8 0-184.8zM398.8 388c-7.8 19.6-22.9 34.7-42.6 42.6-29.5 11.7-99.5 9-132.1 9s-102.7 2.6-132.1-9c-19.6-7.8-34.7-22.9-42.6-42.6-11.7-29.5-9-99.5-9-132.1s-2.6-102.7 9-132.1c7.8-19.6 22.9-34.7 42.6-42.6 29.5-11.7 99.5-9 132.1-9s102.7-2.6 132.1 9c19.6 7.8 34.7 22.9 42.6 42.6 11.7 29.5 9 99.5 9 132.1s2.7 102.7-9 132.1z"/></svg>
+              <% end %>
+            <% end %>
+            <% if @user.facebook_link.present? %>
+              <%= link_to "#{@user.facebook_link}" do %>
+              <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 320 512" class="w-5 h-5 mx-2"><!--! Font Awesome Pro 6.0.0 by @fontawesome - https://fontawesome.com License - https://fontawesome.com/license (Commercial License) Copyright 2022 Fonticons, Inc. --><path fill="currentColor" d="M279.14 288l14.22-92.66h-88.91v-60.13c0-25.35 12.42-50.06 52.24-50.06h40.42V6.26S260.43 0 225.36 0c-73.22 0-121.08 44.38-121.08 124.72v70.62H22.89V288h81.39v224h100.17V288z"/></svg>
+              <% end %>
+            <% end %>
+          </div>
         </div>
       </div>
     </div>

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -31,7 +31,7 @@
       <div>
         <div class="p-2">
           <h2 class="font-bold text-lg">自己紹介</h2>
-          <% if @user.introduction.empty? %>
+          <% if @user.introduction.blank? %>
             <p>未設定</p>
           <% end %>
           <p><%= @user.introduction %></p>
@@ -39,7 +39,7 @@
         <div class="p-2">
           <h2 class="font-bold text-lg">SNS</h2>
           <div class="flex">
-            <% if @user.twitter_link.empty? && @user.instagram_link && @user.facebook_link%>
+            <% if @user.twitter_link.blank? && @user.instagram_link.blank? && @user.facebook_link.blank? %>
               <p>未設定</p>
             <% end %>
             <% if @user.twitter_link.present? %>

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -18,14 +18,14 @@
             <h2 class="font-bold text-lg">ユーザー名</h2>
             <p><%= @user.name %><p>
           </div>
-          <h1 class="text-xl font-bold text-amber-700 m-4">
+          <h2 class="text-xl font-bold text-amber-700 m-4">
             <% if @user.target_calorie.present? %>
               1日の目標カロリー<br>
               <%= @user.target_calorie %> kcal
             <% else %>
               目標カロリー未設定
             <% end%>
-          </h1>
+          </h2>
         </div>
       </div>
       <div>
@@ -75,20 +75,20 @@
     <% end %>
   </div>
   <div class="flex flex-col mt-8">
-    <h1 class="text-xl font-bold mx-8 my-4">
+    <h2 class="text-xl font-bold mx-8 my-4">
       <%= @input_date.strftime("%Y年%m月%d日") %> の記録
-    </h1>
+    </h2>
     <% if @total_calorie.present? && @user.target_calorie.present? %>
-    <h1 class="text-xl font-bold mx-8 my-4 text-center text-primary-focus">
+    <h2 class="text-xl font-bold mx-8 my-4 text-center text-primary-focus">
       目標カロリーに対して 
       <span class="text-red-500"><%= (@total_calorie.to_f / @user.target_calorie.to_f * 100).round(0) %> %</span>
       の達成率 <br>
       (合計<span class="text-red-500"><%= @total_calorie %> kcal</span> 摂取)
-    </h1>
+    </h2>
     <% end %>
   </div>
   <div class="flex flex-col w-full my-8">
-    <h1 class="text-xl font-bold mx-8 my-4">筋トレ</h1>
+    <h2 class="text-xl font-bold mx-8 my-4">筋トレ</h2>
     <div class="grid card rounded-box">
       <div class="md:flex md:flex-wrap md:justify-start justify-center">
         <% if @workouts.present? %>
@@ -99,7 +99,7 @@
       </div>
     </div> 
     <div class="divider"></div> 
-    <h1 class="text-xl font-bold mx-8 my-4">食事</h1>
+    <h2 class="text-xl font-bold mx-8 my-4">食事</h2>
     <div class="grid card rounded-box">
       <div class="md:flex md:flex-wrap md:justify-start justify-center">
         <% if @meals.present? %>

--- a/spec/system/profiles_spec.rb
+++ b/spec/system/profiles_spec.rb
@@ -6,6 +6,8 @@ RSpec.describe 'Profiles', js: true do
   it 'プロフィール登録すると、プロフィール表示画面に遷移し、情報が表示されること' do
     login_as(user)
     visit edit_profile_path
+    fill_in '名前(必須)', with: user.name
+    fill_in 'メールアドレス(必須)', with: user.email
     fill_in '身長(必須)', with: user.height
     fill_in '体重(必須)', with: user.body_weight
     fill_in '年齢(必須)', with: user.age


### PR DESCRIPTION
## 概要
- プロフィール編集画面からユーザー名とemailアドレスを変更できるように機能追加
- マイページの自己紹介文とSNSについて設定がない場合には`未設定`が表示されるように修正
- SNSリンクはsvgアイコンとなるように修正

## 確認方法
- ログイン後、プロフィール編集画面から名前とemailを変更できることを確認。

## 影響範囲
usersリソース、マイページのビュー

## チェックリスト
- [x] Lint のチェックをパスした
- [x] テストをパスした

## コメント
- 異常系のRSpecテストを書く必要あり
close #83 