### PR TITLE
[set_default_date#152] フォームにデフォルトの日付表示追加

### DIFF
--- a/app/views/meals/new.html.erb
+++ b/app/views/meals/new.html.erb
@@ -11,7 +11,7 @@
     <%= render 'shared/error_messages', object: f.object %>
       <div class="form-control">
         <%= f.label :meal_date, class: "text-xl pt-4 font-bold" %>
-        <%= f.date_field :meal_date, class: "input input-bordered" %>
+        <%= f.date_field :meal_date, value: Time.now.strftime("%Y-%m-%d"), class: "input input-bordered" %>
 
         <%= f.label :meal_period, class: "text-xl pt-4 font-bold" %>
         <%= f.select :meal_period, Meal.meal_periods_i18n.invert.map{|key, value| [key, Meal.meal_periods[value]]}, {}, class: "select select-bordered w-ful" %>

--- a/app/views/workouts/new.html.erb
+++ b/app/views/workouts/new.html.erb
@@ -5,7 +5,7 @@
   <%= render 'shared/error_messages', object: f.object %>
     <div class="form-control">
       <%= f.label :workout_date, class: "text-xl pt-4 font-bold" %>
-      <%= f.date_field :workout_date, class: "input input-bordered" %>
+      <%= f.date_field :workout_date, value: Time.now.strftime("%Y-%m-%d"), class: "input input-bordered" %>
 
       <%= f.label :workout_title, class: "text-xl pt-4 font-bold"  %>
       <%= f.text_field :workout_title, class: "input input-bordered" %>


### PR DESCRIPTION
## 概要
- 筋トレ投稿と食事投稿での日付入力欄に`value`属性で、今日の日付を指定し、デフォルト値を入力

## 確認方法
-  ブラウザにてデフォルト値が入力されていることを確認

## 影響範囲
食事、筋トレの投稿フォームビュー（`meals/new.html.erb`, `workouts/new.html.erb`）

## チェックリスト
- [ ] Lint のチェックをパスした
- [ ] テストをパスした

## コメント
- datetime型のカラムの場合、date型の形式に直して`.to_s`する必要あり。（valueの引数に渡すと内部的に`.to_s`してくれる模様）

```
(参考)
> Time.now
=> 2023-02-01 22:08:04.532708 +0900

> Time.now.class
=> Time

> Time.now.strftime("%Y-%m-%d")
=> "2023-02-01"

> Time.now.to_date
=> Wed, 01 Feb 2023

> Time.now.to_date.class
=> Date

> Time.now.to_date.to_s
=> "2023-02-01"

```
