### PR TITLE
[add_validation_to_active_storage#142] Active Storageのカスタムバリデーション追加

### DIFF
--- a/app/forms/meal_form.rb
+++ b/app/forms/meal_form.rb
@@ -18,7 +18,6 @@ class MealForm
   attribute :meal_calorie_third, :integer
   attribute :meal_images
 
-  validates :meal_date, presence: true
   validates :meal_title_first, presence: true
   validates :meal_weight_first, presence: true
   validates :meal_calorie_first, presence: true
@@ -59,6 +58,7 @@ class MealForm
     end
     meal
   rescue ActiveRecord::RecordInvalid
+    errors.merge!(meal.errors)
     false
   end
 
@@ -71,15 +71,15 @@ class MealForm
   attr_reader :meal
 
   def default_attributes
-    meal_title_first = meal.meal_details.first.nil? ? '' : meal.meal_details.first.meal_title
-    meal_weight_first = meal.meal_details.first.nil? ? '' : meal.meal_details.first.meal_weight
-    meal_calorie_first = meal.meal_details.first.nil? ? '' : meal.meal_details.first.meal_calorie
-    meal_title_second = meal.meal_details.second.nil? ? '' : meal.meal_details.second.meal_title
-    meal_weight_second = meal.meal_details.second.nil? ? '' : meal.meal_details.second.meal_weight
-    meal_calorie_second = meal.meal_details.second.nil? ? '' : meal.meal_details.second.meal_calorie
-    meal_title_third = meal.meal_details.third.nil? ? '' : meal.meal_details.third.meal_title
-    meal_weight_third = meal.meal_details.third.nil? ? '' : meal.meal_details.third.meal_weight
-    meal_calorie_third = meal.meal_details.third.nil? ? '' : meal.meal_details.third.meal_calorie
+    meal_title_first = meal.meal_details.first.nil? ? nil : meal.meal_details.first.meal_title
+    meal_weight_first = meal.meal_details.first.nil? ? nil : meal.meal_details.first.meal_weight
+    meal_calorie_first = meal.meal_details.first.nil? ? nil : meal.meal_details.first.meal_calorie
+    meal_title_second = meal.meal_details.second.nil? ? nil : meal.meal_details.second.meal_title
+    meal_weight_second = meal.meal_details.second.nil? ? nil : meal.meal_details.second.meal_weight
+    meal_calorie_second = meal.meal_details.second.nil? ? nil : meal.meal_details.second.meal_calorie
+    meal_title_third = meal.meal_details.third.nil? ? nil : meal.meal_details.third.meal_title
+    meal_weight_third = meal.meal_details.third.nil? ? nil : meal.meal_details.third.meal_weight
+    meal_calorie_third = meal.meal_details.third.nil? ? nil : meal.meal_details.third.meal_calorie
     {
       user_id: meal.user_id,
       meal_date: meal.meal_date,

--- a/app/forms/meal_form.rb
+++ b/app/forms/meal_form.rb
@@ -71,15 +71,15 @@ class MealForm
   attr_reader :meal
 
   def default_attributes
-    meal_title_first = meal.meal_details.first.nil? ? nil : meal.meal_details.first.meal_title
-    meal_weight_first = meal.meal_details.first.nil? ? nil : meal.meal_details.first.meal_weight
-    meal_calorie_first = meal.meal_details.first.nil? ? nil : meal.meal_details.first.meal_calorie
-    meal_title_second = meal.meal_details.second.nil? ? nil : meal.meal_details.second.meal_title
-    meal_weight_second = meal.meal_details.second.nil? ? nil : meal.meal_details.second.meal_weight
-    meal_calorie_second = meal.meal_details.second.nil? ? nil : meal.meal_details.second.meal_calorie
-    meal_title_third = meal.meal_details.third.nil? ? nil : meal.meal_details.third.meal_title
-    meal_weight_third = meal.meal_details.third.nil? ? nil : meal.meal_details.third.meal_weight
-    meal_calorie_third = meal.meal_details.third.nil? ? nil : meal.meal_details.third.meal_calorie
+    meal_title_first = meal.meal_details.first&.meal_title
+    meal_weight_first = meal.meal_details.first&.meal_weight
+    meal_calorie_first = meal.meal_details.first&.meal_calorie
+    meal_title_second = meal.meal_details.second&.meal_title
+    meal_weight_second = meal.meal_details.second&.meal_weight
+    meal_calorie_second = meal.meal_details.second&.meal_calorie
+    meal_title_third = meal.meal_details.third&.meal_title
+    meal_weight_third = meal.meal_details.third&.meal_weight
+    meal_calorie_third = meal.meal_details.third&.meal_calorie
     {
       user_id: meal.user_id,
       meal_date: meal.meal_date,

--- a/app/forms/workout_form.rb
+++ b/app/forms/workout_form.rb
@@ -48,6 +48,7 @@ class WorkoutForm
     end
     workout
   rescue ActiveRecord::RecordInvalid
+    errors.merge!(workout.errors)
     false
   end
 

--- a/app/models/meal.rb
+++ b/app/models/meal.rb
@@ -6,6 +6,9 @@ class Meal < ApplicationRecord
     attachable.variant :thumb, resize_to_limit: [400, 400]
   end
 
+  validates :meal_date, presence: true
+  validates :meal_images, attachment: { purge: true, content_type: %r{\Aimage/(png|jpeg|jpg)\Z}, maximum: 5_242_880 }
+
   enum meal_period: { breakfast: 0, lunch: 1, dinner: 2, nosh: 3 }
   enum meal_type: { self_catering: 0, eating_out: 1, to_go: 2, convenience_store: 3 }
 end

--- a/app/models/workout.rb
+++ b/app/models/workout.rb
@@ -3,14 +3,15 @@ class Workout < ApplicationRecord
   has_many :workout_body_parts, dependent: :destroy
   has_many :body_parts, through: :workout_body_parts
 
+  has_many_attached :workout_images do |attachable|
+    attachable.variant :thumb, resize_to_limit: [400, 400]
+  end
+
   validates :workout_date, presence: true
   validates :workout_title, presence: true
   validates :workout_time, presence: true
   validates :workout_weight, presence: true
   validates :repetition_count, presence: true
   validates :set_count, presence: true
-
-  has_many_attached :workout_images do |attachable|
-    attachable.variant :thumb, resize_to_limit: [400, 400]
-  end
+  validates :workout_images, attachment: { purge: true, content_type: %r{\Aimage/(png|jpeg|jpg)\Z}, maximum: 5_242_880 }
 end

--- a/app/validators/attachment_validator.rb
+++ b/app/validators/attachment_validator.rb
@@ -1,0 +1,48 @@
+class AttachmentValidator < ActiveModel::EachValidator
+  include ActiveSupport::NumberHelper
+
+  def validate_each(record, attribute, value)
+    return if value.blank? || !value.attached?
+
+    has_error = false
+
+    if options[:maximum]
+      value.each do |v|
+        unless validate_maximum(record, attribute, v)
+          has_error = true
+          break
+        end
+      end
+    end
+
+    if options[:content_type]
+      value.each do |v|
+        unless validate_content_type(record, attribute, v)
+          has_error = true
+          break
+        end
+      end
+    end
+    record.send(attribute).purge if options[:purge] && has_error
+  end
+
+  private
+
+  def validate_maximum(record, attribute, value)
+    if value.byte_size > options[:maximum]
+      record.errors.add(attribute, "は#{number_to_human_size(options[:maximum])}以下にしてください")
+      false
+    else
+      true
+    end
+  end
+
+  def validate_content_type(record, attribute, value)
+    if value.content_type.match?(options[:content_type])
+      true
+    else
+      record.errors.add(attribute, 'は対応できないファイル形式です')
+      false
+    end
+  end
+end

--- a/app/views/meals/edit.html.erb
+++ b/app/views/meals/edit.html.erb
@@ -73,10 +73,10 @@
       <%= f.file_field :meal_images, class: "input input-bordered", multiple: true %>
     </div>
     <div class="flex flex-col items-start my-3">
-      <% if @meal_form.meal_images.attached? %>
+      <% if @meal.meal_images.attached? %>
         <h1 class="text-xl pt-4 font-bold">アップロード済み画像</h1>
         <div class="flex flex-wrap">
-          <% @meal_form.meal_images.each do |meal_image|%>
+          <% @meal.meal_images.each do |meal_image|%>
           <div><%= image_tag meal_image.variant(:thumb), class: "m-2" if meal_image.representable? %></div>
           <% end %>
         </div>


### PR DESCRIPTION
## 概要
- ActiveStorageのバリデーションを設定
  - 画像の保存容量は5MBまで
  - 拡張子はpng, jpeg, jpg

## 確認方法
- それぞれの投稿から確認

## 影響範囲
- mealモデルおよびmeal_formモデル、workoutモデルおよびworkout_formモデル

## チェックリスト
- [x] Lint のチェックをパスした
- [x] テストをパスした

## コメント
- テストに反映させるか検討
