### PR TITLE
[debug#159] workoutモデルへバリデーション移譲、editビューの修正

### DIFF
--- a/app/forms/workout_form.rb
+++ b/app/forms/workout_form.rb
@@ -13,13 +13,7 @@ class WorkoutForm
   attribute :workout_images
   attribute :user_id
 
-  validates :workout_date, presence: true
-  validates :workout_title, presence: true
   validates :body_part_ids, presence: true
-  validates :workout_time, presence: true
-  validates :workout_weight, presence: true
-  validates :repetition_count, presence: true
-  validates :set_count, presence: true
 
   delegate :persisted?, to: :workout
 

--- a/app/views/workouts/edit.html.erb
+++ b/app/views/workouts/edit.html.erb
@@ -30,10 +30,10 @@
       <%= f.file_field :workout_images, class: "input input-bordered", multiple: true %>
     </div>
     <div class="flex flex-col items-start my-3">
-      <% if @workout_form.workout_images.attached? %>
+      <% if @workout.workout_images.attached? %>
         <h1 class="text-xl pt-4 font-bold">アップロード済み画像</h1>
         <div class="flex flex-wrap">
-          <% @workout_form.workout_images.each do |workout_image|%>
+          <% @workout.workout_images.each do |workout_image|%>
           <div><%= image_tag workout_image.variant(:thumb), class: "m-2" if workout_image.representable? %></div>
           <% end %>
         </div>


### PR DESCRIPTION
## 概要
 - 筋トレ投稿の更新時、バリデーションエラーとなるファイルをあげたときに500エラーとなる点を修正
 - WorkoutFormオブジェクトモデルから、Workoutモデルへ一部バリデーションを移譲

## 影響範囲
Workoutモデル

## チェックリスト
- [x] Lint のチェックをパスした
- [x] テストをパスした

## コメント
- もともと画像の付いていた投稿に対し、バリデーションエラーのファイルを添付して更新すると、更新成功するがファイル自体は削除される挙動となっているため、要検討。
close #159
