### PR TITLE
[Add follow function#143] フォロー機能の実装

### DIFF
--- a/app/controllers/meals_controller.rb
+++ b/app/controllers/meals_controller.rb
@@ -66,6 +66,10 @@ class MealsController < ApplicationController
     render :new
   end
 
+  def meals_feed
+    @feed_items = Meal.where(user_id: [*current_user.following_ids]).order(meal_date: :desc).page(params[:page])
+  end
+
   private
 
   def meal_params

--- a/app/controllers/relationships_controller.rb
+++ b/app/controllers/relationships_controller.rb
@@ -1,0 +1,21 @@
+class RelationshipsController < ApplicationController
+  before_action :require_login
+
+  def create
+    @user = User.find(params[:followed_id])
+    current_user.follow(@user)
+    respond_to do |format|
+      format.html { redirect_to @user }
+      format.turbo_stream
+    end
+  end
+
+  def destroy
+    @user = Relationship.find(params[:id]).followed
+    current_user.unfollow(@user)
+    respond_to do |format|
+      format.html { redirect_to @user, status: :see_other }
+      format.turbo_stream
+    end
+  end
+end

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -24,6 +24,20 @@ class UsersController < ApplicationController
     end
   end
 
+  def followings
+    @title = 'フォロー一覧'
+    @user  = User.find(params[:id])
+    @users = @user.followings.page(params[:page])
+    render 'show_follow'
+  end
+
+  def followers
+    @title = 'フォロワー一覧'
+    @user  = User.find(params[:id])
+    @users = @user.followers.page(params[:page])
+    render 'show_follow'
+  end
+
   def date_search
     user_id = params[:user_id]
     @user = User.find(user_id)

--- a/app/controllers/workouts_controller.rb
+++ b/app/controllers/workouts_controller.rb
@@ -55,6 +55,10 @@ class WorkoutsController < ApplicationController
     redirect_to user_path(current_user), success: t('defaults.message.deleted', item: Workout.model_name.human)
   end
 
+  def workouts_feed
+    @feed_items = Workout.where(user_id: [*current_user.following_ids]).order(workout_date: :desc).page(params[:page])
+  end
+
   private
 
   def workout_params

--- a/app/models/relationship.rb
+++ b/app/models/relationship.rb
@@ -1,0 +1,2 @@
+class Relationship < ApplicationRecord
+end

--- a/app/models/relationship.rb
+++ b/app/models/relationship.rb
@@ -1,2 +1,6 @@
 class Relationship < ApplicationRecord
+  belongs_to :follower, class_name: "User"
+  belongs_to :followed, class_name: "User"
+  validates :follower_id, presence: true
+  validates :followed_id, presence: true
 end

--- a/app/models/relationship.rb
+++ b/app/models/relationship.rb
@@ -1,6 +1,4 @@
 class Relationship < ApplicationRecord
-  belongs_to :follower, class_name: "User"
-  belongs_to :followed, class_name: "User"
-  validates :follower_id, presence: true
-  validates :followed_id, presence: true
+  belongs_to :follower, class_name: 'User'
+  belongs_to :followed, class_name: 'User'
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -7,6 +7,10 @@ class User < ApplicationRecord
   has_many :workouts, dependent: :destroy
   has_many :meals, dependent: :destroy
   has_many :meal_details, through: :meals
+  has_many :relationships, class_name: "Relationship", foreign_key: "follower_id", dependent: :destroy
+  has_many :reverse_of_relationships, class_name: "Relationship", foreign_key: "followed_id", dependent: :destroy
+  has_many :followings, through: :relationships, source: :followed
+  has_many :followers, through: :reverse_of_relationships, source: :follower
 
   has_one_attached :avatar do |attachable|
     attachable.variant :thumb, resize_to_limit: [200, 200]
@@ -44,6 +48,18 @@ class User < ApplicationRecord
       end
     self.target_calorie = maintenance_calorie + adjustment_calorie + 300
     save
+  end
+
+  def follow(other_user)
+    followings << other_user unless self == other_user
+  end
+
+  def unfollow(other_user)
+    followings.delete(other_user)
+  end
+
+  def following?(other_user)
+    followings.include?(other_user)
   end
 
   private

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -7,8 +7,8 @@ class User < ApplicationRecord
   has_many :workouts, dependent: :destroy
   has_many :meals, dependent: :destroy
   has_many :meal_details, through: :meals
-  has_many :relationships, class_name: "Relationship", foreign_key: "follower_id", dependent: :destroy
-  has_many :reverse_of_relationships, class_name: "Relationship", foreign_key: "followed_id", dependent: :destroy
+  has_many :relationships, class_name: 'Relationship', foreign_key: 'follower_id', dependent: :destroy
+  has_many :reverse_of_relationships, class_name: 'Relationship', foreign_key: 'followed_id', dependent: :destroy
   has_many :followings, through: :relationships, source: :followed
   has_many :followers, through: :reverse_of_relationships, source: :follower
 

--- a/app/views/meals/meals_feed.html.erb
+++ b/app/views/meals/meals_feed.html.erb
@@ -5,12 +5,12 @@
       <h1 class="text-xl font-bold"><%= t '.title' %></h1>
     </div>
     <div class="flex flex-wrap w-full">
-      <% if @meals.present? %>
-        <%= render @meals %>
+      <% if @feed_items.present? %>
+        <%= render partial: 'meal', collection: @feed_items, as: 'meal' %>
       <% else %>
         <p><%= t('.no_result') %></p>
       <% end %>
     </div>
-    <div class="flex md:justify-center btn-group w-screen"><%= paginate @meals %></div>
+    <div class="flex md:justify-center btn-group w-screen"><%= paginate @feed_items %></div>
   </div>
 </div>

--- a/app/views/relationships/create.turbo_stream.erb
+++ b/app/views/relationships/create.turbo_stream.erb
@@ -1,0 +1,7 @@
+<%= turbo_stream.update "follow_form" do %>
+  <%= render partial: "users/unfollow" %>
+<% end %>
+<%= turbo_stream.update "followers" do %>
+  <%= @user.followers.count %>
+  フォロワー
+<% end %>

--- a/app/views/relationships/destroy.turbo_stream.erb
+++ b/app/views/relationships/destroy.turbo_stream.erb
@@ -1,0 +1,7 @@
+<%= turbo_stream.update "follow_form" do %>
+  <%= render partial: "users/follow" %>
+<% end %>
+<%= turbo_stream.update "followers" do %>
+  <%= @user.followers.count %>
+  フォロワー
+<% end %>

--- a/app/views/shared/_sidebar.html.erb
+++ b/app/views/shared/_sidebar.html.erb
@@ -18,13 +18,19 @@
       </div>
       <ul tabindex="0" class="dropdown-content menu p-2 shadow bg-base-100 rounded-box w-52">
         <li class="dropdown dropdown-right dropdown-start">
-        <span class="to-workout-index">筋トレ投稿一覧</span>
+        <span class="to-workouts-index">筋トレ投稿一覧</span>
           <ul tabindex="0" class="dropdown-content menu p-2 shadow bg-base-100 rounded-box w-52">
             <li><%= link_to 'フォローユーザー', workouts_feed_path %></li>
             <li><%= link_to '全ユーザー', workouts_path %></li>
           </ul>
         </li>
-        <li><%= link_to '食事投稿一覧', meals_path %></li>
+        <li class="dropdown dropdown-right dropdown-start">
+        <span class="to-meals-index">食事投稿一覧</span>
+          <ul tabindex="0" class="dropdown-content menu p-2 shadow bg-base-100 rounded-box w-52">
+            <li><%= link_to 'フォローユーザー', meals_feed_path %></li>
+            <li><%= link_to '全ユーザー', meals_path %></li>
+          </ul>
+        </li>
       </ul>
     </div>
     <div class="menu dropdown dropdown-right py-2">
@@ -53,17 +59,22 @@
     <path stroke-linecap="round" stroke-linejoin="round" d="M6 6.878V6a2.25 2.25 0 012.25-2.25h7.5A2.25 2.25 0 0118 6v.878m-12 0c.235-.083.487-.128.75-.128h10.5c.263 0 .515.045.75.128m-12 0A2.25 2.25 0 004.5 9v.878m13.5-3A2.25 2.25 0 0119.5 9v.878m0 0a2.246 2.246 0 00-.75-.128H5.25c-.263 0-.515.045-.75.128m15 0A2.25 2.25 0 0121 12v6a2.25 2.25 0 01-2.25 2.25H5.25A2.25 2.25 0 013 18v-6c0-.98.626-1.813 1.5-2.122" />
     </svg>
     <span tabindex="0" class="btm-nav-label">投稿一覧</span>
-      <ul tabindex="0" class="dropdown-content menu p-2 shadow bg-base-100 rounded-box">
-          
-        <li class="dropdown dropdown-right dropdown-end">
-          <span>筋トレ</span>
-          <ul tabindex="0" class="dropdown-content menu p-2 shadow bg-base-100 rounded-box w-32">
-            <li><%= link_to 'フォロー中', workouts_feed_path %></li>
-            <li><%= link_to '全ユーザー', workouts_path %></li>
-          </ul>
-        </li>
-        <li><%= link_to '食事', meals_path %></li>
-      </ul>
+    <ul tabindex="0" class="dropdown-content menu p-2 shadow bg-base-100 rounded-box">
+      <li class="dropdown dropdown-right dropdown-end">
+        <span>筋トレ</span>
+        <ul tabindex="0" class="dropdown-content menu p-2 shadow bg-base-200 rounded-box w-32">
+          <li><%= link_to 'フォロー中', workouts_feed_path %></li>
+          <li><%= link_to '全ユーザー', workouts_path %></li>
+        </ul>
+      </li>
+      <li class="dropdown dropdown-right dropdown-end">
+        <span>食事</span>
+        <ul tabindex="0" class="dropdown-content menu p-2 shadow bg-base-200 rounded-box w-32">
+          <li><%= link_to 'フォロー中', meals_feed_path %></li>
+          <li><%= link_to '全ユーザー', meals_path %></li>
+        </ul>
+      </li>
+    </ul>
   </div>
   <div class="flex flex-col items-center dropdown dropdown-top dropdown-end">
     <svg xmlns="http://www.w3.org/2000/svg" class="h-5 w-5" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" tabindex="0">

--- a/app/views/shared/_sidebar.html.erb
+++ b/app/views/shared/_sidebar.html.erb
@@ -17,7 +17,13 @@
         <label tabindex="0" class="font-bold m-2">投稿一覧</label>
       </div>
       <ul tabindex="0" class="dropdown-content menu p-2 shadow bg-base-100 rounded-box w-52">
-        <li><%= link_to '筋トレ投稿一覧', workouts_path %></li>
+        <li class="dropdown dropdown-right dropdown-start">
+        <span class="to-workout-index">筋トレ投稿一覧</span>
+          <ul tabindex="0" class="dropdown-content menu p-2 shadow bg-base-100 rounded-box w-52">
+            <li><%= link_to 'フォローユーザー', workouts_feed_path %></li>
+            <li><%= link_to '全ユーザー', workouts_path %></li>
+          </ul>
+        </li>
         <li><%= link_to '食事投稿一覧', meals_path %></li>
       </ul>
     </div>
@@ -47,9 +53,16 @@
     <path stroke-linecap="round" stroke-linejoin="round" d="M6 6.878V6a2.25 2.25 0 012.25-2.25h7.5A2.25 2.25 0 0118 6v.878m-12 0c.235-.083.487-.128.75-.128h10.5c.263 0 .515.045.75.128m-12 0A2.25 2.25 0 004.5 9v.878m13.5-3A2.25 2.25 0 0119.5 9v.878m0 0a2.246 2.246 0 00-.75-.128H5.25c-.263 0-.515.045-.75.128m15 0A2.25 2.25 0 0121 12v6a2.25 2.25 0 01-2.25 2.25H5.25A2.25 2.25 0 013 18v-6c0-.98.626-1.813 1.5-2.122" />
     </svg>
     <span tabindex="0" class="btm-nav-label">投稿一覧</span>
-      <ul tabindex="0" class="dropdown-content menu p-2 shadow bg-base-100 rounded-box w-52">
-        <li><%= link_to '筋トレ投稿一覧', workouts_path %></li>
-        <li><%= link_to '食事投稿一覧', meals_path %></li>
+      <ul tabindex="0" class="dropdown-content menu p-2 shadow bg-base-100 rounded-box">
+          
+        <li class="dropdown dropdown-right dropdown-end">
+          <span>筋トレ</span>
+          <ul tabindex="0" class="dropdown-content menu p-2 shadow bg-base-100 rounded-box w-32">
+            <li><%= link_to 'フォロー中', workouts_feed_path %></li>
+            <li><%= link_to '全ユーザー', workouts_path %></li>
+          </ul>
+        </li>
+        <li><%= link_to '食事', meals_path %></li>
       </ul>
   </div>
   <div class="flex flex-col items-center dropdown dropdown-top dropdown-end">

--- a/app/views/shared/_stats.html.erb
+++ b/app/views/shared/_stats.html.erb
@@ -1,0 +1,14 @@
+<div class="flex justify-center">
+  <%= link_to followings_user_path(@user) do %>
+    <div id="following" class="mx-4">
+      <%= @user.followings.count %>
+      フォロー中
+    </div>
+  <%  end %>
+  <%= link_to followers_user_path(@user) do %>
+    <div id="followers" class="mx-4">
+      <%= @user.followers.count %>
+      フォロワー
+    </div>
+  <%  end %>
+</div>

--- a/app/views/users/_follow.html.erb
+++ b/app/views/users/_follow.html.erb
@@ -1,0 +1,4 @@
+<%= form_with model: current_user.relationships.build do |f| %>
+  <div><%= hidden_field_tag :followed_id, @user.id %></div>
+  <%= f.submit 'フォローする', class: "btn btn-primary" %>
+<% end %>

--- a/app/views/users/_follow_form.html.erb
+++ b/app/views/users/_follow_form.html.erb
@@ -1,0 +1,9 @@
+<% unless current_user == @user %>
+  <div id="follow_form" class="m-4">
+  <% if current_user.following?(@user) %>
+    <%= render 'unfollow' %>
+  <% else %>
+    <%= render 'follow' %>
+  <% end %>
+  </div>
+<% end %>

--- a/app/views/users/_unfollow.html.erb
+++ b/app/views/users/_unfollow.html.erb
@@ -1,0 +1,3 @@
+<%= form_with model: current_user.relationships.find_by(followed: @user), html: { method: :delete } do |f| %>
+  <%= f.submit 'フォロー解除', class: "btn" %>
+<% end %>

--- a/app/views/users/_user.html.erb
+++ b/app/views/users/_user.html.erb
@@ -3,8 +3,8 @@
     <div class="card card-side w-80 bg-base-100 shadow-xl border border-base-300">
       <div class="avatar max-w-max m-4">
         <div class="w-24 h-24 rounded-full ring ring-primary ring-offset-base-100 ring-offset-2">
-          <% if @user.avatar.attached? %>
-          <%= image_tag @user.avatar.variant(:thumb) %>
+          <% if user.avatar.attached? %>
+          <%= image_tag user.avatar.variant(:thumb) %>
           <% else %>
           <%= image_tag('user_sample.png', size: "400x400") %>
           <% end %>

--- a/app/views/users/_user.html.erb
+++ b/app/views/users/_user.html.erb
@@ -1,0 +1,20 @@
+<div id="user-id-<%= user.id %>" class="m-4 max-w-lg">
+  <%=link_to user_path(user) do%>
+    <div class="card card-side w-80 bg-base-100 shadow-xl border border-base-300">
+      <div class="avatar max-w-max m-4">
+        <div class="w-24 h-24 rounded-full ring ring-primary ring-offset-base-100 ring-offset-2">
+          <% if @user.avatar.attached? %>
+          <%= image_tag @user.avatar.variant(:thumb) %>
+          <% else %>
+          <%= image_tag('user_sample.png', size: "400x400") %>
+          <% end %>
+        </div>
+      </div>
+      <div class="card-body">
+        <div class="font-bold text-xl m-2 items-center">
+          <p class="m-2"><%= user.name %></p>
+        </div>
+      </div>
+    </div>
+  <% end %>
+</div>

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -1,44 +1,52 @@
 <% assign_meta_tags title: (t '.title') %>
 <div class="my-page mx-4 my-8">
   <h1 class="text-xl font-bold"><%= @user.name %>さんの<%= t '.title' %></h1>
-  <div class="profile my-4 md:flex md:justify-around md:items-start">
+  <div class="profile my-4 flex flex-wrap text-center md:flex md:justify-around md:items-start">
     <div>
-      <div class="flex max-w-full">
-        <div class="avatar max-w-max my-8 mx-4">
-          <div class="w-24 h-24 rounded-full ring ring-primary ring-offset-base-100 ring-offset-2">
-            <% if @user.avatar.attached? %>
-            <%= image_tag @user.avatar.variant(:thumb) %>
-            <% else %>
-            <%= image_tag('user_sample.png', size: "400x400") %>
-            <% end %>
+      <div class="flex flex-col max-w-full">
+        <div class="flex">
+          <div class="avatar max-w-max m-4">
+            <div class="w-24 h-24 rounded-full ring ring-primary ring-offset-base-100 ring-offset-2">
+              <% if @user.avatar.attached? %>
+              <%= image_tag @user.avatar.variant(:thumb) %>
+              <% else %>
+              <%= image_tag('user_sample.png', size: "400x400") %>
+              <% end %>
+            </div>
+          </div>
+          <div class="flex flex-col">
+            <div class="m-4">
+              <h2 class="font-bold text-lg">ユーザー名</h2>
+              <p><%= @user.name %><p>
+            </div>
+            <h2 class="text-xl font-bold text-amber-700 m-4">
+              <% if @user.target_calorie.present? %>
+                1日の目標カロリー<br>
+                <%= @user.target_calorie %> kcal
+              <% else %>
+                目標カロリー未設定
+              <% end%>
+            </h2>
           </div>
         </div>
-        <div class="flex flex-col">
-          <div class="m-4">
-            <h2 class="font-bold text-lg">ユーザー名</h2>
-            <p><%= @user.name %><p>
-          </div>
-          <h2 class="text-xl font-bold text-amber-700 m-4">
-            <% if @user.target_calorie.present? %>
-              1日の目標カロリー<br>
-              <%= @user.target_calorie %> kcal
-            <% else %>
-              目標カロリー未設定
-            <% end%>
-          </h2>
+        <div>
+          <%= render 'shared/stats' %>
+        </div>
+        <div>
+          <%= render 'follow_form' if logged_in? %>
         </div>
       </div>
-      <div>
-        <div class="p-2">
+      <div class="my-8">
+        <div class="my-4">
           <h2 class="font-bold text-lg">自己紹介</h2>
           <% if @user.introduction.blank? %>
             <p>未設定</p>
           <% end %>
           <p><%= @user.introduction %></p>
         </div>
-        <div class="p-2">
+        <div  class="my-4">
           <h2 class="font-bold text-lg">SNS</h2>
-          <div class="flex">
+          <div class="flex justify-center">
             <% if @user.twitter_link.blank? && @user.instagram_link.blank? && @user.facebook_link.blank? %>
               <p>未設定</p>
             <% end %>

--- a/app/views/users/show_follow.html.erb
+++ b/app/views/users/show_follow.html.erb
@@ -1,0 +1,35 @@
+<% assign_meta_tags title: @title %>
+<div class="mx-4 my-8">
+  <h1 class="text-xl font-bold"><%= @user.name %>さんの<%= @title %></h1>
+  <div>
+    <div class="user_info flex flex-col items-center">
+      <%=link_to user_path(@user) do%>
+        <div class="avatar max-w-max m-4">
+          <div class="w-24 h-24 rounded-full ring ring-primary ring-offset-base-100 ring-offset-2">
+            <% if @user.avatar.attached? %>
+            <%= image_tag @user.avatar.variant(:thumb) %>
+            <% else %>
+            <%= image_tag('user_sample.png', size: "400x400") %>
+            <% end %>
+          </div>
+        </div>
+        <div class="m-2">
+          <h2 class="font-bold text-lg text-center"><%= @user.name %></h2>
+        </div>
+      <%end%>
+      <div>
+        <%= render 'shared/stats' %>
+      </div>
+    </div>
+  </div>
+  <div>
+    <% if @users.present? %>
+      <div class="flex flex-wrap w-full justyfy-center md:justify-start">
+        <%= render @users %>
+      </div>
+    <% end %>
+  </div>
+  <div class="flex justify-center btn-group m-4">
+    <%= paginate @users %>
+  </div>
+</div>

--- a/app/views/workouts/workouts_feed.html.erb
+++ b/app/views/workouts/workouts_feed.html.erb
@@ -5,12 +5,12 @@
       <h1 class="text-xl font-bold"><%= t '.title' %></h1>
     </div>
     <div class="flex flex-wrap w-full">
-      <% if @workouts.present? %>
-        <%= render @workouts %>
+      <% if @feed_items.present? %>
+        <%= render partial: 'workout', collection: @feed_items, as: 'workout' %>
       <% else %>
         <p><%= t('.no_result') %></p>
       <% end %>
     </div>
-    <div class="flex md:justify-center btn-group w-screen"><%= paginate @workouts %></div>
+    <div class="flex md:justify-center btn-group w-screen"><%= paginate @feed_items %></div>
   </div>
 </div>

--- a/config/locales/views/ja.yml
+++ b/config/locales/views/ja.yml
@@ -78,10 +78,11 @@ ja:
       success: "削除しました"
       delete_a_workout: "削除する"
     workouts_feed:
-      title: "フォロー中ユーザーの筋トレ投稿"
+      title: "フォローユーザーの筋トレ投稿"
+      no_result: "投稿がありません"
   meals:
     index:
-      title: "食事投稿一覧"
+      title: "全ユーザーの食事投稿"
       to_workouts_page: "筋トレ投稿一覧へ"
     new:
       title: "食事新規投稿"
@@ -94,6 +95,9 @@ ja:
     destroy:
       success: "削除しました"
       delete_a_meal: "削除する"
+    meals_feed:
+      title: "フォローユーザーの食事投稿"
+      no_result: "投稿がありません"
   password_resets:
     new:
       title: "パスワードリセット申請"

--- a/config/locales/views/ja.yml
+++ b/config/locales/views/ja.yml
@@ -64,7 +64,7 @@ ja:
       success: "退会しました"
   workouts:
     index:
-      title: "筋トレ投稿一覧"
+      title: "全ユーザーの筋トレ投稿"
       to_meals_page: "食事投稿一覧へ"
     new:
       title: "筋トレ新規投稿"
@@ -77,6 +77,8 @@ ja:
     destroy:
       success: "削除しました"
       delete_a_workout: "削除する"
+    workouts_feed:
+      title: "フォロー中ユーザーの筋トレ投稿"
   meals:
     index:
       title: "食事投稿一覧"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -18,6 +18,7 @@ Rails.application.routes.draw do
   resource :profile, only: %i[show edit update destroy]
   resources :workouts
   resources :meals
+  get 'workouts_feed', to: 'workouts#workouts_feed'
   get 'calorie_search', to: 'meals#calorie_search'
   get 'date_search', to: 'users#date_search'
   get 'sitemap', to: redirect("https://s3-ap-northeast-1.amazonaws.com/#{Rails.application.credentials.aws[:s3][:bucket]}/sitemaps/sitemap.xml.gz")

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -9,7 +9,12 @@ Rails.application.routes.draw do
   post 'login', to: 'user_sessions#create'
   delete 'logout', to: 'user_sessions#destroy'
 
-  resources :users, only: %i[show new create]
+  resources :users, only: %i[show new create] do
+    member do
+      get :followings, :followers
+    end
+  end
+  resources :relationships, only: %i[create destroy]
   resource :profile, only: %i[show edit update destroy]
   resources :workouts
   resources :meals

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -19,6 +19,7 @@ Rails.application.routes.draw do
   resources :workouts
   resources :meals
   get 'workouts_feed', to: 'workouts#workouts_feed'
+  get 'meals_feed', to: 'meals#meals_feed'
   get 'calorie_search', to: 'meals#calorie_search'
   get 'date_search', to: 'users#date_search'
   get 'sitemap', to: redirect("https://s3-ap-northeast-1.amazonaws.com/#{Rails.application.credentials.aws[:s3][:bucket]}/sitemaps/sitemap.xml.gz")

--- a/db/migrate/20230205015900_create_relationships.rb
+++ b/db/migrate/20230205015900_create_relationships.rb
@@ -1,0 +1,13 @@
+class CreateRelationships < ActiveRecord::Migration[7.0]
+  def change
+    create_table :relationships, id: :uuid do |t|
+      t.uuid :follower_id
+      t.uuid :followed_id
+
+      t.timestamps
+    end
+    add_index :relationships, :follower_id
+    add_index :relationships, :followed_id
+    add_index :relationships, [:follower_id, :followed_id], unique: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_01_30_060352) do
+ActiveRecord::Schema[7.0].define(version: 2023_02_05_015900) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
   enable_extension "plpgsql"
@@ -68,6 +68,16 @@ ActiveRecord::Schema[7.0].define(version: 2023_01_30_060352) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.index ["user_id"], name: "index_meals_on_user_id"
+  end
+
+  create_table "relationships", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
+    t.uuid "follower_id"
+    t.uuid "followed_id"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["followed_id"], name: "index_relationships_on_followed_id"
+    t.index ["follower_id", "followed_id"], name: "index_relationships_on_follower_id_and_followed_id", unique: true
+    t.index ["follower_id"], name: "index_relationships_on_follower_id"
   end
 
   create_table "users", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|

--- a/db/seeds/development.rb
+++ b/db/seeds/development.rb
@@ -137,3 +137,10 @@ end
   ).save!
 end
 
+# ユーザーフォローのリレーションシップを作成する
+users = User.all
+user  = users.first
+following = users[2..19]
+followers = users[3..10]
+following.each { |followed| user.follow(followed) }
+followers.each { |follower| follower.follow(user) }

--- a/spec/factories/relationships.rb
+++ b/spec/factories/relationships.rb
@@ -1,0 +1,6 @@
+FactoryBot.define do
+  factory :relationship do
+    follower_id { "" }
+    followed_id { "" }
+  end
+end

--- a/spec/factories/relationships.rb
+++ b/spec/factories/relationships.rb
@@ -1,6 +1,6 @@
 FactoryBot.define do
   factory :relationship do
-    follower_id { "" }
-    followed_id { "" }
+    follower_id { '' }
+    followed_id { '' }
   end
 end

--- a/spec/models/relationship_spec.rb
+++ b/spec/models/relationship_spec.rb
@@ -1,0 +1,5 @@
+require 'rails_helper'
+
+RSpec.describe Relationship, type: :model do
+  pending "add some examples to (or delete) #{__FILE__}"
+end

--- a/spec/models/relationship_spec.rb
+++ b/spec/models/relationship_spec.rb
@@ -1,5 +1,5 @@
 require 'rails_helper'
 
-RSpec.describe Relationship, type: :model do
+RSpec.describe Relationship do
   pending "add some examples to (or delete) #{__FILE__}"
 end

--- a/spec/requests/relationships_spec.rb
+++ b/spec/requests/relationships_spec.rb
@@ -1,0 +1,7 @@
+require 'rails_helper'
+
+RSpec.describe "Relationships", type: :request do
+  describe "GET /index" do
+    pending "add some examples (or delete) #{__FILE__}"
+  end
+end

--- a/spec/requests/relationships_spec.rb
+++ b/spec/requests/relationships_spec.rb
@@ -1,7 +1,7 @@
 require 'rails_helper'
 
-RSpec.describe "Relationships", type: :request do
-  describe "GET /index" do
+RSpec.describe 'Relationships' do
+  describe 'GET /index' do
     pending "add some examples (or delete) #{__FILE__}"
   end
 end

--- a/spec/system/meal_form_spec.rb
+++ b/spec/system/meal_form_spec.rb
@@ -25,14 +25,15 @@ RSpec.describe 'MealForm', js: true do
 
   it '未ログインでも食事のタイムラインを閲覧できること' do
     visit meals_path
-    expect(page).to have_content '食事投稿一覧'
+    expect(page).to have_content '全ユーザーの食事投稿'
   end
 
   it 'サイドバーの投稿一覧をクリックすると食事タイムラインが表示されること' do
     login_as(user)
     page.first('.to-index').click
-    click_on '食事投稿一覧'
-    expect(page).to have_content '食事投稿一覧'
+    page.first('.to-meals-index').click
+    click_on '全ユーザー'
+    expect(page).to have_content '全ユーザーの食事投稿'
     expect(page).to have_current_path meals_path, ignore_query: true
   end
 

--- a/spec/system/relationships_spec.rb
+++ b/spec/system/relationships_spec.rb
@@ -1,0 +1,30 @@
+require 'rails_helper'
+
+RSpec.describe 'Relationships', js: true do
+  let(:user) { create(:user) }
+  let(:other_users) { create_list(:user, 20) }
+
+  before do
+    other_users[0..9].each do |other_user|
+      user.relationships.create!(followed_id: other_user.id)
+      user.reverse_of_relationships.create!(follower_id: other_user.id)
+    end
+    login_as(user)
+  end
+
+  it 'ユーザーがフォローできること' do
+    visit user_path(other_users.last.id)
+    expect do
+      click_on 'フォローする'
+      expect(page).not_to have_link 'フォローする'
+    end.to change(user.followings, :count).by(1)
+  end
+
+  it 'ユーザーがアンフォローできること' do
+    visit user_path(other_users.first.id)
+    expect do
+      click_on 'フォロー解除'
+      expect(page).not_to have_link 'フォロー解除'
+    end.to change(user.followings, :count).by(-1)
+  end
+end

--- a/spec/system/workout_form_spec.rb
+++ b/spec/system/workout_form_spec.rb
@@ -28,7 +28,7 @@ RSpec.describe 'WorkoutForm', js: true do
   it 'サイドバーの投稿一覧をクリックすると筋トレのタイムラインが表示されること' do
     login_as(user)
     page.first('.to-index').click
-    page.first('.to-workout-index').click
+    page.first('.to-workouts-index').click
     click_on '全ユーザー'
     expect(page).to have_content '全ユーザーの筋トレ投稿'
     expect(page).to have_current_path workouts_path, ignore_query: true

--- a/spec/system/workout_form_spec.rb
+++ b/spec/system/workout_form_spec.rb
@@ -22,14 +22,15 @@ RSpec.describe 'WorkoutForm', js: true do
 
   it '未ログインでも筋トレのタイムラインを閲覧できること' do
     visit workouts_path
-    expect(page).to have_content '筋トレ投稿一覧'
+    expect(page).to have_content '全ユーザーの筋トレ投稿'
   end
 
   it 'サイドバーの投稿一覧をクリックすると筋トレのタイムラインが表示されること' do
     login_as(user)
     page.first('.to-index').click
-    click_on '筋トレ投稿一覧'
-    expect(page).to have_content '筋トレ投稿一覧'
+    page.first('.to-workout-index').click
+    click_on '全ユーザー'
+    expect(page).to have_content '全ユーザーの筋トレ投稿'
     expect(page).to have_current_path workouts_path, ignore_query: true
   end
 


### PR DESCRIPTION
## 概要
- Relationshipモデルを作成し、フォロー機能を実装
- 投稿一覧を「フォローしている人」、「全員」で出し分け

## 確認方法
- モデルおよびテーブルを追加したので `bundle exec rails db:migrate` を実行

## 影響範囲
ユーザーモデルと筋トレ、食事のindexビュー

## チェックリスト
- [x] Lint のチェックをパスした
- [x] テストをパスした

## コメント
- 今後 テストコードをより充実化させる
close #143