### PR TITLE
[Fix profile update#165] プロフィール画像投稿機能のバリデーション追加、モデルのインスタンスメソッド、update処理修正、ogp微修正

### DIFF
--- a/app/controllers/profiles_controller.rb
+++ b/app/controllers/profiles_controller.rb
@@ -5,9 +5,12 @@ class ProfilesController < ApplicationController
   def edit; end
 
   def update
-    @user.avatar.attach(params[:user][:avatar])
     if @user.update(user_params)
-      @user.save_self_calories
+      if params.dig(:user, :avatar).present?
+        images = ActiveStorage::Attachment.where(record_id: current_user.id)
+        images.each(&:purge)
+        @user.avatar.attach(params[:user][:avatar])
+      end
       redirect_to profile_path, success: t('.success')
     else
       flash.now['danger'] = t('.fail')

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -34,8 +34,8 @@ module ApplicationHelper
         site_name: site
       },
       twitter: {
-        site: '@kosukein38',
-        card: 'summary',
+        site: '@bulkupper',
+        card: 'summary_large_image',
         image:
       }
     }

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -42,7 +42,6 @@ class User < ApplicationRecord
     object.user_id == id
   end
 
-
   def follow(other_user)
     followings << other_user unless self == other_user
   end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,7 +1,7 @@
 class User < ApplicationRecord
   before_update :set_active_level_coefficient
-  before_update :set_self_calories
   before_update :set_default_adjustment_calorie
+  before_update :set_self_calories
 
   authenticates_with_sorcery!
 
@@ -86,6 +86,6 @@ class User < ApplicationRecord
   end
 
   def set_default_adjustment_calorie
-    self.adjustment_calorie = 0 if adjustment_calorie.blank?
+    self.adjustment_calorie ||= 0
   end
 end

--- a/app/validators/attachment_validator.rb
+++ b/app/validators/attachment_validator.rb
@@ -7,20 +7,28 @@ class AttachmentValidator < ActiveModel::EachValidator
     has_error = false
 
     if options[:maximum]
-      value.each do |v|
-        unless validate_maximum(record, attribute, v)
-          has_error = true
-          break
+      if value.is_a?(ActiveStorage::Attached::Many)
+        value.each do |v|
+          unless validate_maximum(record, attribute, v)
+            has_error = true
+            break
+          end
         end
+      else
+        has_error = true unless validate_maximum(record, attribute, value)
       end
     end
 
     if options[:content_type]
-      value.each do |v|
-        unless validate_content_type(record, attribute, v)
-          has_error = true
-          break
+      if value.is_a?(ActiveStorage::Attached::Many)
+        value.each do |v|
+          unless validate_content_type(record, attribute, v)
+            has_error = true
+            break
+          end
         end
+      else
+        has_error = true unless validate_content_type(record, attribute, value)
       end
     end
     record.send(attribute).purge if options[:purge] && has_error

--- a/app/views/profiles/edit.html.erb
+++ b/app/views/profiles/edit.html.erb
@@ -74,6 +74,14 @@
       <%= f.number_field :adjustment_calorie, class: "form-control input input-bordered" %>
       <%= f.label :avatar, class: "text-xl pt-4 font-bold" %>
       <%= f.file_field :avatar %>
+      <div class="flex flex-col items-start my-3">
+        <% if @user.avatar.attached? %>
+          <h1 class="text-xl pt-4 font-bold">アップロード済み画像</h1>
+          <div class="flex flex-wrap">
+            <div><%= image_tag @user.avatar.variant(:thumb), class: "m-2" if @user.avatar.representable? %></div>
+          </div>
+        <% end %>
+      </div>
       <%= f.submit '更新する', class: "btn btn-primary my-4"%>
     </div>
     <% end %>


### PR DESCRIPTION
## 概要
- プロフィール画像投稿機能にバリデーションを追加
  - サイズは5MBまで
  - 拡張子はjpeg, jpg, png
- profileモデルのインスタンスメソッドを修正
- updateアクションの処理を修正
-  ogp微修正

## 確認方法
- ブラウザおよびテストで確認

## 影響範囲
userモデル

## チェックリスト
- [x] Lint のチェックをパスした
- [x] テストをパスした

## コメント
- twitter ogpは大きな画像イメージとなるように修正
close #165 
