### PR TITLE
[Bugfix#171]食事投稿のupdate時のバグ修正

### DIFF
--- a/app/forms/meal_form.rb
+++ b/app/forms/meal_form.rb
@@ -96,15 +96,15 @@ class MealForm
   attr_reader :meal
 
   def default_attributes
-    meal_title_first = meal.meal_details.first&.meal_title
-    meal_weight_first = meal.meal_details.first&.meal_weight
-    meal_calorie_first = meal.meal_details.first&.meal_calorie
-    meal_title_second = meal.meal_details.second&.meal_title
-    meal_weight_second = meal.meal_details.second&.meal_weight
-    meal_calorie_second = meal.meal_details.second&.meal_calorie
-    meal_title_third = meal.meal_details.third&.meal_title
-    meal_weight_third = meal.meal_details.third&.meal_weight
-    meal_calorie_third = meal.meal_details.third&.meal_calorie
+    meal_title_first = meal.meal_details.first.nil? ? '' : meal.meal_details.first.meal_title
+    meal_weight_first = meal.meal_details.first.nil? ? '' : meal.meal_details.first.meal_weight
+    meal_calorie_first = meal.meal_details.first.nil? ? '' : meal.meal_details.first.meal_calorie
+    meal_title_second = meal.meal_details.second.nil? ? '' : meal.meal_details.second.meal_title
+    meal_weight_second = meal.meal_details.second.nil? ? '' : meal.meal_details.second.meal_weight
+    meal_calorie_second = meal.meal_details.second.nil? ? '' : meal.meal_details.second.meal_calorie
+    meal_title_third = meal.meal_details.third.nil? ? '' : meal.meal_details.third.meal_title
+    meal_weight_third = meal.meal_details.third.nil? ? '' : meal.meal_details.third.meal_weight
+    meal_calorie_third = meal.meal_details.third.nil? ? '' : meal.meal_details.third.meal_calorie
     {
       user_id: meal.user_id,
       meal_date: meal.meal_date,

--- a/app/forms/meal_form.rb
+++ b/app/forms/meal_form.rb
@@ -33,15 +33,15 @@ class MealForm
   def save
     return false if invalid?
 
-    #bugfix
+    # bugfix
     if meal.meal_details.size > 3
       n = meal.meal_details.size
-      while n > 3 do
-        meal.meal_details[n-1].delete
+      while n > 3
+        meal.meal_details[n - 1].delete
         n -= 1
       end
     end
-    #ここまで
+    # ここまで
 
     ActiveRecord::Base.transaction do
       if meal.meal_images.blank?
@@ -53,33 +53,33 @@ class MealForm
       if meal.meal_details.blank?
         meal.meal_details.create!(meal_title: meal_title_first, meal_weight: meal_weight_first, meal_calorie: meal_calorie_first)
       else
-        meal.meal_details.first.update!(meal_title: meal_title_first, meal_weight: meal_weight_first, meal_calorie: meal_calorie_first)
+        meal.meal_details.first.update!(meal_title: meal_title_first, meal_weight: meal_weight_first,
+                                        meal_calorie: meal_calorie_first)
       end
 
       if meal_title_second.blank?
         next if meal.meal_details.second.nil?
+
         meal.meal_details.second.delete
+      elsif meal.meal_details.second.blank?
+        meal.meal_details.build(meal_title: meal_title_second, meal_weight: meal_weight_second,
+                                meal_calorie: meal_calorie_second).save!
       else
-        if meal.meal_details.second.blank?
-          meal.meal_details.build(meal_title: meal_title_second, meal_weight: meal_weight_second,
-            meal_calorie: meal_calorie_second).save!
-        else
-          meal.meal_details.second.update!(meal_title: meal_title_second, meal_weight: meal_weight_second, meal_calorie: meal_calorie_second)
-        end
+        meal.meal_details.second.update!(meal_title: meal_title_second, meal_weight: meal_weight_second,
+                                         meal_calorie: meal_calorie_second)
       end
 
       if meal_title_third.blank?
         next if meal.meal_details.third.nil?
-        meal.meal_details.third.delete
-      else
-        if meal.meal_details.third.blank?
-          meal.meal_details.build(meal_title: meal_title_third, meal_weight: meal_weight_third,
-            meal_calorie: meal_calorie_third).save!
-        else
-          meal.meal_details.third.update!(meal_title: meal_title_third, meal_weight: meal_weight_third, meal_calorie: meal_calorie_third)
-        end
-      end
 
+        meal.meal_details.third.delete
+      elsif meal.meal_details.third.blank?
+        meal.meal_details.build(meal_title: meal_title_third, meal_weight: meal_weight_third,
+                                meal_calorie: meal_calorie_third).save!
+      else
+        meal.meal_details.third.update!(meal_title: meal_title_third, meal_weight: meal_weight_third,
+                                        meal_calorie: meal_calorie_third)
+      end
     end
     meal
   rescue ActiveRecord::RecordInvalid

--- a/app/forms/meal_form.rb
+++ b/app/forms/meal_form.rb
@@ -33,6 +33,16 @@ class MealForm
   def save
     return false if invalid?
 
+    #bugfix
+    if meal.meal_details.size > 3
+      n = meal.meal_details.size
+      while n > 3 do
+        meal.meal_details[n-1].delete
+        n -= 1
+      end
+    end
+    #ここまで
+
     ActiveRecord::Base.transaction do
       if meal.meal_images.blank?
         meal.update!(meal_date:, meal_period:, meal_type:, meal_memo:, user_id:, meal_images:)
@@ -43,18 +53,33 @@ class MealForm
       if meal.meal_details.blank?
         meal.meal_details.create!(meal_title: meal_title_first, meal_weight: meal_weight_first, meal_calorie: meal_calorie_first)
       else
-        meal.meal_details.update!(meal_title: meal_title_first, meal_weight: meal_weight_first, meal_calorie: meal_calorie_first)
+        meal.meal_details.first.update!(meal_title: meal_title_first, meal_weight: meal_weight_first, meal_calorie: meal_calorie_first)
       end
 
-      unless meal_title_second.empty?
-        meal.meal_details.build(meal_title: meal_title_second, meal_weight: meal_weight_second,
-                                meal_calorie: meal_calorie_second).save!
+      if meal_title_second.blank?
+        next if meal.meal_details.second.nil?
+        meal.meal_details.second.delete
+      else
+        if meal.meal_details.second.blank?
+          meal.meal_details.build(meal_title: meal_title_second, meal_weight: meal_weight_second,
+            meal_calorie: meal_calorie_second).save!
+        else
+          meal.meal_details.second.update!(meal_title: meal_title_second, meal_weight: meal_weight_second, meal_calorie: meal_calorie_second)
+        end
       end
 
-      unless meal_title_third.empty?
-        meal.meal_details.build(meal_title: meal_title_third, meal_weight: meal_weight_third,
-                                meal_calorie: meal_calorie_third).save!
+      if meal_title_third.blank?
+        next if meal.meal_details.third.nil?
+        meal.meal_details.third.delete
+      else
+        if meal.meal_details.third.blank?
+          meal.meal_details.build(meal_title: meal_title_third, meal_weight: meal_weight_third,
+            meal_calorie: meal_calorie_third).save!
+        else
+          meal.meal_details.third.update!(meal_title: meal_title_third, meal_weight: meal_weight_third, meal_calorie: meal_calorie_third)
+        end
       end
+
     end
     meal
   rescue ActiveRecord::RecordInvalid


### PR DESCRIPTION
## 概要
- 食事投稿更新時のバグ修正
- `Meal`モデルの子モデルである`MealDetail`がupdateではなくcreate

## 確認方法

## 影響範囲
Mealモデル、MealDetailモデル

## チェックリスト

- [x] Lint のチェックをパスした
- [x] ユニットテストをパスした

## コメント
- 応急措置、今後動的フォームを実装する際に、再度修正
close #171 