### PR TITLE
[fix_flash_messages#175] フラッシュメッセージの修正 #175

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,5 +1,5 @@
 class ApplicationController < ActionController::Base
-  add_flash_types :success, :info, :warning, :danger
+  add_flash_types :success, :info, :warning, :error
   before_action :require_login
 
   private

--- a/app/controllers/meals_controller.rb
+++ b/app/controllers/meals_controller.rb
@@ -26,7 +26,7 @@ class MealsController < ApplicationController
     if @meal_form.save
       redirect_to user_path(current_user.id), success: t('defaults.message.created', item: Meal.model_name.human)
     else
-      flash.now['danger'] = t('defaults.message.not_created', item: Meal.model_name.human)
+      flash.now['error'] = t('defaults.message.not_created', item: Meal.model_name.human)
       render :new, status: :unprocessable_entity
     end
   end
@@ -43,7 +43,7 @@ class MealsController < ApplicationController
       end
       redirect_to user_path(current_user), success: t('defaults.message.updated', item: Meal.model_name.human)
     else
-      flash.now['danger'] = t('defaults.message.not_updated', item: Meal.model_name.human)
+      flash.now['error'] = t('defaults.message.not_updated', item: Meal.model_name.human)
       render :edit, status: :unprocessable_entity
     end
   end

--- a/app/controllers/password_resets_controller.rb
+++ b/app/controllers/password_resets_controller.rb
@@ -33,7 +33,7 @@ class PasswordResetsController < ApplicationController
       end
       redirect_to root_path, success: t('.success')
     else
-      flash.now['danger'] = t('.fail')
+      flash.now['error'] = t('.fail')
       render :edit, status: :unprocessable_entity
     end
   end

--- a/app/controllers/profiles_controller.rb
+++ b/app/controllers/profiles_controller.rb
@@ -13,7 +13,7 @@ class ProfilesController < ApplicationController
       end
       redirect_to profile_path, success: t('.success')
     else
-      flash.now['danger'] = t('.fail')
+      flash.now['error'] = t('.fail')
       render :edit, status: :unprocessable_entity
     end
   end

--- a/app/controllers/user_sessions_controller.rb
+++ b/app/controllers/user_sessions_controller.rb
@@ -8,7 +8,7 @@ class UserSessionsController < ApplicationController
     if @user
       redirect_back_or_to profile_path, success: t('.success')
     else
-      flash.now[:danger] = t('.fail')
+      flash.now[:error] = t('.fail')
       render :new, status: :unprocessable_entity
     end
   end

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -19,7 +19,7 @@ class UsersController < ApplicationController
     if @user.save
       redirect_to login_path, success: t('.success')
     else
-      flash.now['danger'] = t('.fail')
+      flash.now['error'] = t('.fail')
       render :new, status: :unprocessable_entity
     end
   end

--- a/app/controllers/workouts_controller.rb
+++ b/app/controllers/workouts_controller.rb
@@ -26,7 +26,7 @@ class WorkoutsController < ApplicationController
     if @workout_form.save
       redirect_to user_path(current_user), success: t('defaults.message.created', item: Workout.model_name.human)
     else
-      flash.now['danger'] = t('defaults.message.not_created', item: Workout.model_name.human)
+      flash.now['error'] = t('defaults.message.not_created', item: Workout.model_name.human)
       render :new, status: :unprocessable_entity
     end
   end
@@ -43,7 +43,7 @@ class WorkoutsController < ApplicationController
       end
       redirect_to user_path(current_user), success: t('defaults.message.updated', item: Workout.model_name.human)
     else
-      flash.now['danger'] = t('defaults.message.not_updated', item: Workout.model_name.human)
+      flash.now['error'] = t('defaults.message.not_updated', item: Workout.model_name.human)
       render :edit, status: :unprocessable_entity
     end
   end

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -22,10 +22,10 @@
   <body class="min-h-screen">
     <% if logged_in? %>
       <%= render 'shared/header' %>
-      <%= render 'shared/flash_message' %>
       <div class="main-wrapper flex">
         <%= render 'shared/sidebar' %>
         <div class="main-content container mx-auto">
+          <%= render 'shared/flash_message' %>
           <%= yield %>
         </div>
       </div>

--- a/app/views/shared/_flash_message.html.erb
+++ b/app/views/shared/_flash_message.html.erb
@@ -1,5 +1,5 @@
 <% flash.each do |message_type, message| %>
-  <div class="alert alert-<%= message_type %> shadow-lg">
+  <div class="alert alert-<%= message_type %> shadow-lg m-4 w-auto">
     <div>
       <%= message %>
     </div>

--- a/app/views/workouts/new.html.erb
+++ b/app/views/workouts/new.html.erb
@@ -7,14 +7,15 @@
       <%= f.label :workout_date, class: "text-xl pt-4 font-bold" %>
       <%= f.date_field :workout_date, value: Time.now.strftime("%Y-%m-%d"), class: "input input-bordered" %>
 
-      <%= f.label :workout_title, class: "text-xl pt-4 font-bold"  %>
+      <%= f.label :workout_title, class: "text-xl pt-4 font-bold" %>
       <%= f.text_field :workout_title, class: "input input-bordered" %>
 
-      <%= f.label :body_part_ids, class: "text-xl pt-4 font-bold"  %>
+      <%= f.label :body_part_ids, class: "text-xl pt-4 font-bold" %>
       <div class="flex flex-wrap justify-start">
         <%= f.collection_check_boxes(:body_part_ids, BodyPart.all, :id, :body_part_name, {include_hidden: false}, {class: "checkbox"}) do |body_part| %>
-          <div class="m-4">
-          <%= body_part.label { body_part.check_box + body_part.text }%>
+          <div class="m-4 flex">
+            <%= body_part.check_box %>
+            <%= body_part.label { body_part.text }%>
           </div>
         <% end%>
       </div>


### PR DESCRIPTION
## 概要
- フラッシュメッセージのcssがうまく当たらなかった部分を修正
- danger => errorに修正

## 確認方法
ブラウザ上でcssを確認

## 影響範囲
フラッシュメッセージのビュー

## チェックリスト
- [x] Lint のチェックをパスした
- [x] テストをパスした

## コメント
- フラッシュメッセージのcssにマージンを設けた
- ログイン後のPCビューではサイドバーの隣に表示するように修正
close #175 