### PR TITLE
[convert_text_to_html#181] メモ中のurlがはみ出して表示されてしまうcssを修正 #181

### DIFF
--- a/app/helpers/static_pages_helper.rb
+++ b/app/helpers/static_pages_helper.rb
@@ -1,2 +1,0 @@
-module StaticPagesHelper
-end

--- a/app/views/meals/show.html.erb
+++ b/app/views/meals/show.html.erb
@@ -57,7 +57,7 @@
           </div>
           <div class="mx-8 mt-4">
             <h2 class="text-xl font-bold">メモ</h2>
-            <p class="text-base md:w-96"><%= @meal.meal_memo %></p>
+            <p class="text-base md:w-96 break-words"><%= @meal.meal_memo %></p>
           </div>
           <div class="mx-8 mt-4">
           <% if logged_in? && current_user.own?(@meal) %>

--- a/app/views/workouts/show.html.erb
+++ b/app/views/workouts/show.html.erb
@@ -57,7 +57,7 @@
           </div>
           <div class="mx-8 mt-4">
             <h2 class="text-xl font-bold">メモ</h2>
-            <p class="text-base md:w-96"><%= @workout.workout_memo %></p>
+            <p class="text-base md:w-96 break-words"><%= @workout.workout_memo %></p>
           </div>
           <div class="mx-8 mt-4">
           <% if logged_in? && current_user.own?(@workout) %>


### PR DESCRIPTION
## 概要
- 食事と筋トレ投稿のメモで、`break-words`のcss修正

## 確認方法
- ブラウザにて確認

## 影響範囲
食事と筋トレ投稿の(showビュー)

## チェックリスト
- [x] Lint のチェックをパスした
- [x] テストをパスした

## コメント
- ユーザーが入力したurlをリンク化して表示することを考えたが、セキュリティ上好ましくないと考えたため、エスケープしたまま、css表示のみ修正することとした。
close #181 