### PR TITLE
[Fix] CSS崩れ修正 #187

### DIFF
--- a/app/views/meals/_meal.html.erb
+++ b/app/views/meals/_meal.html.erb
@@ -1,19 +1,19 @@
-<div class="card card-compact h-28 bg-base-100 shadow-xl image-full m-4 md:card-side md:w-96">
+<div class="card card-compact h-28 bg-base-100 shadow-xl image-full mx-4 my-2 md:card-side md:w-96">
   <% if meal.meal_images.attached? %>
     <figure><%= image_tag meal.meal_images.last.variant(:thumb) %></figure>
   <% else %>
     <figure><%= image_tag('meal_sample.jpg', size: "400x400") %></figure>
   <% end %>
   <%= link_to meal_path(meal.id) do %>
-  <div class="card-body flex flex-row items-center justify-around">
-    <div>
-      <h2 class="card-title"><%= meal.meal_details.pluck(:meal_title).join(',') %></h2>
+  <div class="card-body flex flex-row justify-start">
+    <div class="w-44 self-start">
+      <h2 class="card-title truncate block"><%= meal.meal_details.pluck(:meal_title).join(',') %></h2>
       <p><%= meal.meal_details.pluck(:meal_calorie).sum %> kcal / <%= meal.meal_period_i18n %></p>
       <p><%= meal.meal_date.strftime("%Y年%m月%d日") %></p>
     </div>
-    <div>
+    <div class="w-auto">
       <%=link_to user_path(meal.user) do%>
-        <div class="flex flex-col items-center">
+        <div class="flex flex-col items-center mx-4">
           <div class="avatar">
             <div class="w-12 rounded-full ring ring-primary ring-offset-base-100 ring-offset-2">
               <% if meal.user.avatar.attached? %>

--- a/app/views/workouts/_workout.html.erb
+++ b/app/views/workouts/_workout.html.erb
@@ -1,17 +1,17 @@
-<div class="card card-compact h-28 bg-base-100 shadow-xl image-full m-4 md:card-side md:w-96">
+<div class="card card-compact h-28 bg-base-100 shadow-xl image-full mx-4 my-2 md:card-side md:w-96">
   <% if workout.workout_images.attached? %>
     <figure><%= image_tag workout.workout_images.last.variant(:thumb) %></figure>
   <% else %>
     <figure><%= image_tag('workout_sample.jpg', size: "400x400") %></figure>
   <% end %>
   <%= link_to workout_path(workout.id) do %>
-  <div class="card-body flex flex-row items-center justify-around">
-    <div>
-      <h2 class="card-title"><%= workout.workout_title %></h2>
+  <div class="card-body flex flex-row ijustify-start">
+    <div class="w-44">
+      <h2 class="card-title truncate block"><%= workout.workout_title %></h2>
       <p><%= workout.workout_weight %> kg /<%= workout.repetition_count %> reps /<%= workout.set_count %> sets </p>
-      <p><%= workout.workout_date.strftime("%Y年%m月%d日") %></p>
+      <p><%= workout.workout_date.strftime("%Y/%m/%d") %></p>
     </div>
-    <div>
+    <div class="w-auto">
       <%=link_to user_path(workout.user) do%>
         <div class="flex flex-col items-center mx-4">
           <div class="avatar">


### PR DESCRIPTION
## 概要
- カード表示のタイトルが長くあった場合に表示が崩れてしまうため、UI修正

## 確認方法
- ブラウザにて確認

## 影響範囲
- 食事と筋トレの一覧ビュー

## チェックリスト
- [x] Lint のチェックをパスした
- [x] テストをパスした

## コメント
- 食事と筋トレの動線を見直し
close #187 
