### PR TITLE
[Modify menu UI#190] メニュー表示の修正、ログイン後の遷移先変更

### DIFF
--- a/app/controllers/meals_controller.rb
+++ b/app/controllers/meals_controller.rb
@@ -7,7 +7,7 @@ class MealsController < ApplicationController
 
   def show
     @meal = Meal.find(params[:id])
-    @user = User.find(@meal.user_id)
+    @user = @meal.user
   end
 
   def new

--- a/app/controllers/user_sessions_controller.rb
+++ b/app/controllers/user_sessions_controller.rb
@@ -6,7 +6,7 @@ class UserSessionsController < ApplicationController
   def create
     @user = login(params[:email], params[:password])
     if @user
-      redirect_back_or_to profile_path, success: t('.success')
+      redirect_back_or_to user_path(@user), success: t('.success')
     else
       flash.now[:error] = t('.fail')
       render :new, status: :unprocessable_entity
@@ -32,6 +32,6 @@ class UserSessionsController < ApplicationController
       )
     end
     auto_login(@guest_user)
-    redirect_to root_path, success: 'ゲストとしてログインしました'
+    redirect_to user_path(@guest_user), success: 'ゲストとしてログインしました'
   end
 end

--- a/app/views/shared/_sidebar.html.erb
+++ b/app/views/shared/_sidebar.html.erb
@@ -1,90 +1,45 @@
-<div class="sidebar hidden md:flex md:flex-col md:min-w-max md:p-4 md:bg-base-300 md:drop-shadow-lg md:rounded-md z-50">
-  <nav>
-    <div class="py-2">
-      <%= link_to user_path(current_user.id) do %>
-        <div class="to_mypage flex">
-          <svg xmlns="http://www.w3.org/2000/svg" class="h-5 w-5 m-2" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-          <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M3 12l2-2m0 0l7-7 7 7M5 10v10a1 1 0 001 1h3m10-11l2 2m-2-2v10a1 1 0 01-1 1h-3m-6 0a1 1 0 001-1v-4a1 1 0 011-1h2a1 1 0 011 1v4a1 1 0 001 1m-6 0h6" /></svg>
-          <span class="btm-nav-label m-2 font-bold">マイページ</span>
-        </div>
-      <% end %>
-    </div>
-    <div class="menu dropdown dropdown-right py-2">
-      <div class="to-index flex">
-        <svg xmlns="http://www.w3.org/2000/svg" class="h-5 w-5 m-2" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor">
-        <path stroke-linecap="round" stroke-linejoin="round" d="M6 6.878V6a2.25 2.25 0 012.25-2.25h7.5A2.25 2.25 0 0118 6v.878m-12 0c.235-.083.487-.128.75-.128h10.5c.263 0 .515.045.75.128m-12 0A2.25 2.25 0 004.5 9v.878m13.5-3A2.25 2.25 0 0119.5 9v.878m0 0a2.246 2.246 0 00-.75-.128H5.25c-.263 0-.515.045-.75.128m15 0A2.25 2.25 0 0121 12v6a2.25 2.25 0 01-2.25 2.25H5.25A2.25 2.25 0 013 18v-6c0-.98.626-1.813 1.5-2.122" />
-        </svg>
-        <label tabindex="0" class="font-bold m-2">投稿一覧</label>
-      </div>
-      <ul tabindex="0" class="dropdown-content menu p-2 shadow bg-base-100 rounded-box w-52">
-        <li class="dropdown dropdown-right dropdown-start">
-        <span class="to-workouts-index">筋トレ投稿一覧</span>
-          <ul tabindex="0" class="dropdown-content menu p-2 shadow bg-base-100 rounded-box w-52">
-            <li><%= link_to 'フォローユーザー', workouts_feed_path %></li>
-            <li><%= link_to '全ユーザー', workouts_path %></li>
-          </ul>
-        </li>
-        <li class="dropdown dropdown-right dropdown-start">
-        <span class="to-meals-index">食事投稿一覧</span>
-          <ul tabindex="0" class="dropdown-content menu p-2 shadow bg-base-100 rounded-box w-52">
-            <li><%= link_to 'フォローユーザー', meals_feed_path %></li>
-            <li><%= link_to '全ユーザー', meals_path %></li>
-          </ul>
-        </li>
-      </ul>
-    </div>
-    <div class="menu dropdown dropdown-right py-2">
-      <div class="to-new-post flex">
-        <svg xmlns="http://www.w3.org/2000/svg" class="h-5 w-5 m-2" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" tabindex="0">
-        <path stroke-linecap="round" stroke-linejoin="round" d="M16.862 4.487l1.687-1.688a1.875 1.875 0 112.652 2.652L10.582 16.07a4.5 4.5 0 01-1.897 1.13L6 18l.8-2.685a4.5 4.5 0 011.13-1.897l8.932-8.931zm0 0L19.5 7.125M18 14v4.75A2.25 2.25 0 0115.75 21H5.25A2.25 2.25 0 013 18.75V8.25A2.25 2.25 0 015.25 6H10" />
-        </svg>
-        <label tabindex="0" class="font-bold m-2">新規投稿作成</label>
-      </div>
-      <ul tabindex="0" class="dropdown-content menu p-2 shadow bg-base-100 rounded-box w-52">
-        <li><%= link_to '新規筋トレ投稿', new_workout_path %></li>
-        <li><%= link_to '新規食事投稿', new_meal_path %></li>
-      </ul>
-    </div>
-  </nav>
-</div>
-<div class="btm-nav z-50 md:hidden bg-base-300">
+<div class="sidebar hidden md:flex md:flex-col md:align-center md:min-w-max md:p-4 md:bg-base-300 md:drop-shadow-lg md:rounded-md md:m-2 z-50">
   <%= link_to user_path(current_user.id) do %>
-    <div class="flex flex-col items-center">
-      <svg xmlns="http://www.w3.org/2000/svg" class="h-5 w-5" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M3 12l2-2m0 0l7-7 7 7M5 10v10a1 1 0 001 1h3m10-11l2 2m-2-2v10a1 1 0 01-1 1h-3m-6 0a1 1 0 001-1v-4a1 1 0 011-1h2a1 1 0 011 1v4a1 1 0 001 1m-6 0h6" /></svg>
+    <div class="to_mypage flex hover:opacity-50 py-2">
+      <svg xmlns="http://www.w3.org/2000/svg" class="w-5 m-2" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M3 12l2-2m0 0l7-7 7 7M5 10v10a1 1 0 001 1h3m10-11l2 2m-2-2v10a1 1 0 01-1 1h-3m-6 0a1 1 0 001-1v-4a1 1 0 011-1h2a1 1 0 011 1v4a1 1 0 001 1m-6 0h6" /></svg>
+      <span class="btm-nav-label m-2 font-bold">マイページ</span>
+    </div>
+  <% end %>
+  <%= link_to new_workout_path do %>
+    <div class="flex hover:opacity-50 py-2">
+      <svg xmlns="http://www.w3.org/2000/svg" class="w-5 m-2" viewBox="0 0 640 512"><!--! Font Awesome Pro 6.3.0 by @fontawesome - https://fontawesome.com License - https://fontawesome.com/license (Commercial License) Copyright 2023 Fonticons, Inc. --><path d="M112 96c0-17.7 14.3-32 32-32h16c17.7 0 32 14.3 32 32V224v64V416c0 17.7-14.3 32-32 32H144c-17.7 0-32-14.3-32-32V384H64c-17.7 0-32-14.3-32-32V288c-17.7 0-32-14.3-32-32s14.3-32 32-32V160c0-17.7 14.3-32 32-32h48V96zm416 0v32h48c17.7 0 32 14.3 32 32v64c17.7 0 32 14.3 32 32s-14.3 32-32 32v64c0 17.7-14.3 32-32 32H528v32c0 17.7-14.3 32-32 32H480c-17.7 0-32-14.3-32-32V288 224 96c0-17.7 14.3-32 32-32h16c17.7 0 32 14.3 32 32zM416 224v64H224V224H416z"/></svg>
+      <span class="btm-nav-label m-2 font-bold">新規筋トレ投稿</span>
+    </div>
+  <% end %>
+  <%= link_to new_meal_path do %>
+    <div class="flex hover:opacity-50 py-2">
+      <svg xmlns="http://www.w3.org/2000/svg" class="w-5 m-2" viewBox="0 0 448 512"><!--! Font Awesome Pro 6.3.0 by @fontawesome - https://fontawesome.com License - https://fontawesome.com/license (Commercial License) Copyright 2023 Fonticons, Inc. --><path d="M416 0C400 0 288 32 288 176V288c0 35.3 28.7 64 64 64h32V480c0 17.7 14.3 32 32 32s32-14.3 32-32V352 240 32c0-17.7-14.3-32-32-32zM64 16C64 7.8 57.9 1 49.7 .1S34.2 4.6 32.4 12.5L2.1 148.8C.7 155.1 0 161.5 0 167.9c0 45.9 35.1 83.6 80 87.7V480c0 17.7 14.3 32 32 32s32-14.3 32-32V255.6c44.9-4.1 80-41.8 80-87.7c0-6.4-.7-12.8-2.1-19.1L191.6 12.5c-1.8-8-9.3-13.3-17.4-12.4S160 7.8 160 16V150.2c0 5.4-4.4 9.8-9.8 9.8c-5.1 0-9.3-3.9-9.8-9L127.9 14.6C127.2 6.3 120.3 0 112 0s-15.2 6.3-15.9 14.6L83.7 151c-.5 5.1-4.7 9-9.8 9c-5.4 0-9.8-4.4-9.8-9.8V16zm48.3 152l-.3 0-.3 0 .3-.7 .3 .7z"/></svg>
+      <span class="btm-nav-label m-2 font-bold">新規食事投稿</span>
+    </div>
+  <% end %>
+</div>
+<!-- スマホ用メニュー -->
+<div class="btm-nav z-50 md:hidden bg-base-300">
+  <%= link_to new_workout_path do %>
+    <div class="flex flex-col items-center hover:opacity-50">
+      <svg xmlns="http://www.w3.org/2000/svg" class="h-5" viewBox="0 0 640 512"><!--! Font Awesome Pro 6.3.0 by @fontawesome - https://fontawesome.com License - https://fontawesome.com/license (Commercial License) Copyright 2023 Fonticons, Inc. --><path d="M112 96c0-17.7 14.3-32 32-32h16c17.7 0 32 14.3 32 32V224v64V416c0 17.7-14.3 32-32 32H144c-17.7 0-32-14.3-32-32V384H64c-17.7 0-32-14.3-32-32V288c-17.7 0-32-14.3-32-32s14.3-32 32-32V160c0-17.7 14.3-32 32-32h48V96zm416 0v32h48c17.7 0 32 14.3 32 32v64c17.7 0 32 14.3 32 32s-14.3 32-32 32v64c0 17.7-14.3 32-32 32H528v32c0 17.7-14.3 32-32 32H480c-17.7 0-32-14.3-32-32V288 224 96c0-17.7 14.3-32 32-32h16c17.7 0 32 14.3 32 32zM416 224v64H224V224H416z"/></svg>
+      <span class="btm-nav-label">新規筋トレ投稿</span>
+    </div>
+  <% end %>
+
+  <%= link_to user_path(current_user.id) do %>
+    <div class="flex flex-col items-center  hover:opacity-50">
+      <svg xmlns="http://www.w3.org/2000/svg" class="h-5" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M3 12l2-2m0 0l7-7 7 7M5 10v10a1 1 0 001 1h3m10-11l2 2m-2-2v10a1 1 0 01-1 1h-3m-6 0a1 1 0 001-1v-4a1 1 0 011-1h2a1 1 0 011 1v4a1 1 0 001 1m-6 0h6" /></svg>
       <span class="btm-nav-label">マイページ</span>
     </div>
   <% end %>
-  <div class="flex flex-col items-center dropdown dropdown-top dropdown-end">
-    <svg xmlns="http://www.w3.org/2000/svg" class="h-5 w-5" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor">
-    <path stroke-linecap="round" stroke-linejoin="round" d="M6 6.878V6a2.25 2.25 0 012.25-2.25h7.5A2.25 2.25 0 0118 6v.878m-12 0c.235-.083.487-.128.75-.128h10.5c.263 0 .515.045.75.128m-12 0A2.25 2.25 0 004.5 9v.878m13.5-3A2.25 2.25 0 0119.5 9v.878m0 0a2.246 2.246 0 00-.75-.128H5.25c-.263 0-.515.045-.75.128m15 0A2.25 2.25 0 0121 12v6a2.25 2.25 0 01-2.25 2.25H5.25A2.25 2.25 0 013 18v-6c0-.98.626-1.813 1.5-2.122" />
-    </svg>
-    <span tabindex="0" class="btm-nav-label">投稿一覧</span>
-    <ul tabindex="0" class="dropdown-content menu p-2 shadow bg-base-100 rounded-box">
-      <li class="dropdown dropdown-right dropdown-end">
-        <span>筋トレ</span>
-        <ul tabindex="0" class="dropdown-content menu p-2 shadow bg-base-200 rounded-box w-32">
-          <li><%= link_to 'フォロー中', workouts_feed_path %></li>
-          <li><%= link_to '全ユーザー', workouts_path %></li>
-        </ul>
-      </li>
-      <li class="dropdown dropdown-right dropdown-end">
-        <span>食事</span>
-        <ul tabindex="0" class="dropdown-content menu p-2 shadow bg-base-200 rounded-box w-32">
-          <li><%= link_to 'フォロー中', meals_feed_path %></li>
-          <li><%= link_to '全ユーザー', meals_path %></li>
-        </ul>
-      </li>
-    </ul>
-  </div>
-  <div class="flex flex-col items-center dropdown dropdown-top dropdown-end">
-    <svg xmlns="http://www.w3.org/2000/svg" class="h-5 w-5" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" tabindex="0">
-    <path stroke-linecap="round" stroke-linejoin="round" d="M16.862 4.487l1.687-1.688a1.875 1.875 0 112.652 2.652L10.582 16.07a4.5 4.5 0 01-1.897 1.13L6 18l.8-2.685a4.5 4.5 0 011.13-1.897l8.932-8.931zm0 0L19.5 7.125M18 14v4.75A2.25 2.25 0 0115.75 21H5.25A2.25 2.25 0 013 18.75V8.25A2.25 2.25 0 015.25 6H10" />
-    </svg>
-    <span tabindex="0" class="btm-nav-label">新規投稿作成</span>
-      <ul tabindex="0" class="dropdown-content menu p-2 shadow bg-base-100 rounded-box w-52">
-        <li><%= link_to '新規筋トレ投稿', new_workout_path %></li>
-        <li><%= link_to '新規食事投稿', new_meal_path %></li>
-      </ul>
-  </div>
+
+  <%= link_to new_meal_path do %>
+    <div class="flex flex-col items-center hover:opacity-50">
+      <svg xmlns="http://www.w3.org/2000/svg" class="h-5" viewBox="0 0 448 512"><!--! Font Awesome Pro 6.3.0 by @fontawesome - https://fontawesome.com License - https://fontawesome.com/license (Commercial License) Copyright 2023 Fonticons, Inc. --><path d="M416 0C400 0 288 32 288 176V288c0 35.3 28.7 64 64 64h32V480c0 17.7 14.3 32 32 32s32-14.3 32-32V352 240 32c0-17.7-14.3-32-32-32zM64 16C64 7.8 57.9 1 49.7 .1S34.2 4.6 32.4 12.5L2.1 148.8C.7 155.1 0 161.5 0 167.9c0 45.9 35.1 83.6 80 87.7V480c0 17.7 14.3 32 32 32s32-14.3 32-32V255.6c44.9-4.1 80-41.8 80-87.7c0-6.4-.7-12.8-2.1-19.1L191.6 12.5c-1.8-8-9.3-13.3-17.4-12.4S160 7.8 160 16V150.2c0 5.4-4.4 9.8-9.8 9.8c-5.1 0-9.3-3.9-9.8-9L127.9 14.6C127.2 6.3 120.3 0 112 0s-15.2 6.3-15.9 14.6L83.7 151c-.5 5.1-4.7 9-9.8 9c-5.4 0-9.8-4.4-9.8-9.8V16zm48.3 152l-.3 0-.3 0 .3-.7 .3 .7z"/></svg>
+      <span class="btm-nav-label">新規食事投稿</span>
+    </div>
+  <% end %>
 </div>
 

--- a/app/views/users/_date_search.html.erb
+++ b/app/views/users/_date_search.html.erb
@@ -20,8 +20,13 @@
     </div>
     <% end %>
   </div>
+
   <div class="flex flex-col w-full my-8">
-    <h2 class="text-xl font-bold m-4">筋トレ</h2>
+
+      <h2 class="text-xl font-bold m-4">筋トレ</h2>
+
+
+
     <div class="grid card rounded-box">
       <div class="h-fit md:flex md:flex-wrap">
         <% if @workouts.present? %>
@@ -30,7 +35,24 @@
           <p class="text-xl mx-8 my-4"><%= t('.no_result') %></p>
         <% end %>
       </div>
+      <div tabindex="0" class="collapse collapse-arrow border border-base-300 bg-base-200 rounded-box m-4 md:w-96">
+        <input type="checkbox" /> 
+        <div class="collapse-title text-sm font-medium flex items-center">
+          <label class="flex">
+            <svg xmlns="http://www.w3.org/2000/svg" class="h-5 w-5" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor">
+            <path stroke-linecap="round" stroke-linejoin="round" d="M6 6.878V6a2.25 2.25 0 012.25-2.25h7.5A2.25 2.25 0 0118 6v.878m-12 0c.235-.083.487-.128.75-.128h10.5c.263 0 .515.045.75.128m-12 0A2.25 2.25 0 004.5 9v.878m13.5-3A2.25 2.25 0 0119.5 9v.878m0 0a2.246 2.246 0 00-.75-.128H5.25c-.263 0-.515.045-.75.128m15 0A2.25 2.25 0 0121 12v6a2.25 2.25 0 01-2.25 2.25H5.25A2.25 2.25 0 013 18v-6c0-.98.626-1.813 1.5-2.122" />
+            </svg>
+            <span class="mx-2">他のユーザー投稿を参考にする</span>
+          </label>
+        </div>
+        <div class="collapse-content flex justify-center"> 
+          <%= button_to 'フォロー中', workouts_feed_path, method: :get, class: "btn btn-sm btn-secondary mx-2" %>
+          <%= button_to '全ユーザー', workouts_path, method: :get, class: "btn btn-sm btn-secondary mx-2" %>
+        </div>
+      </div>
     </div> 
+
+
     <div class="divider"></div> 
     <h2 class="text-xl font-bold m-4">食事</h2>
       <% if @total_calorie.present? && @user.target_calorie.present? %>
@@ -48,6 +70,21 @@
         <% else %>
           <p class="text-xl mx-8 my-4"><%= t('.no_result') %></p>
         <% end %>
+      </div>
+      <div tabindex="0" class="collapse collapse-arrow border border-base-300 bg-base-200 rounded-box m-4 md:w-96">
+        <input type="checkbox" /> 
+        <div class="collapse-title text-sm font-medium flex items-center">
+          <label class="flex">
+            <svg xmlns="http://www.w3.org/2000/svg" class="h-5 w-5" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor">
+            <path stroke-linecap="round" stroke-linejoin="round" d="M6 6.878V6a2.25 2.25 0 012.25-2.25h7.5A2.25 2.25 0 0118 6v.878m-12 0c.235-.083.487-.128.75-.128h10.5c.263 0 .515.045.75.128m-12 0A2.25 2.25 0 004.5 9v.878m13.5-3A2.25 2.25 0 0119.5 9v.878m0 0a2.246 2.246 0 00-.75-.128H5.25c-.263 0-.515.045-.75.128m15 0A2.25 2.25 0 0121 12v6a2.25 2.25 0 01-2.25 2.25H5.25A2.25 2.25 0 013 18v-6c0-.98.626-1.813 1.5-2.122" />
+            </svg>
+            <span class="mx-2">他のユーザー投稿を参考にする</span>
+          </label>
+        </div>
+        <div class="collapse-content flex justify-center"> 
+          <%= button_to 'フォロー中', meals_feed_path, method: :get, class: "btn btn-sm btn-secondary mx-2" %>
+          <%= button_to '全ユーザー', meals_path, method: :get, class: "btn btn-sm btn-secondary mx-2" %>
+        </div>
       </div>
     </div>
   </div>

--- a/spec/system/meal_form_spec.rb
+++ b/spec/system/meal_form_spec.rb
@@ -28,15 +28,6 @@ RSpec.describe 'MealForm', js: true do
     expect(page).to have_content '全ユーザーの食事投稿'
   end
 
-  it 'サイドバーの投稿一覧をクリックすると食事タイムラインが表示されること' do
-    login_as(user)
-    page.first('.to-index').click
-    page.first('.to-meals-index').click
-    click_on '全ユーザー'
-    expect(page).to have_content '全ユーザーの食事投稿'
-    expect(page).to have_current_path meals_path, ignore_query: true
-  end
-
   it '新規食事投稿画面から食事の記録を登録できること' do
     login_as(user)
     visit new_meal_path

--- a/spec/system/user_sessions_spec.rb
+++ b/spec/system/user_sessions_spec.rb
@@ -11,7 +11,7 @@ RSpec.describe 'UserSessions' do
         fill_in 'パスワード(必須)', with: 'password'
         click_button 'ログイン'
         expect(page).to have_content 'ログインしました'
-        expect(page).to have_current_path profile_path, ignore_query: true
+        expect(page).to have_current_path user_path(user), ignore_query: true
       end
     end
 
@@ -45,16 +45,16 @@ RSpec.describe 'UserSessions' do
         expect(page).to have_content 'マイページ'
       end
 
-      it 'ログイン後サイドバーが表示され、投稿一覧のリンクがあること' do
+      it 'ログイン後サイドバーが表示され、新規筋トレ投稿のリンクがあること' do
         login_as(user)
         visit profile_path
-        expect(page).to have_content '投稿一覧'
+        expect(page).to have_content '新規筋トレ投稿'
       end
 
-      it 'ログイン後サイドバーが表示され、新規投稿作成のリンクがあること' do
+      it 'ログイン後サイドバーが表示され、新規食事投稿のリンクがあること' do
         login_as(user)
         visit profile_path
-        expect(page).to have_content '新規投稿作成'
+        expect(page).to have_content '新規食事投稿'
       end
     end
   end

--- a/spec/system/workout_form_spec.rb
+++ b/spec/system/workout_form_spec.rb
@@ -25,15 +25,6 @@ RSpec.describe 'WorkoutForm', js: true do
     expect(page).to have_content '全ユーザーの筋トレ投稿'
   end
 
-  it 'サイドバーの投稿一覧をクリックすると筋トレのタイムラインが表示されること' do
-    login_as(user)
-    page.first('.to-index').click
-    page.first('.to-workouts-index').click
-    click_on '全ユーザー'
-    expect(page).to have_content '全ユーザーの筋トレ投稿'
-    expect(page).to have_current_path workouts_path, ignore_query: true
-  end
-
   it '新規筋トレ投稿画面から筋トレの記録（種目名、トレーニング時間、重量、回数、セット数）を登録できること' do
     login_as(user)
     visit new_workout_path


### PR DESCRIPTION
## 概要
- PC表示のサイドバーとスマホ表示のボトムメニューのUIを修正
- ログイン後の遷移先をマイページに変更

## 確認方法
ブラウザおよびテストで確認

## 影響範囲
- `_sidebar`パーシャルを使用しているビュー
- マイページ(`users#show`)
- user_sessionsコントローラー

## チェックリスト
- [ ] Lint のチェックをパスした
- [ ] テストをパスした

## コメント
- ユーザーの動線を考え修正
  - 1. マイページで自分の投稿を確認
  - 2. (誰かのメニューを取り入れたい)
  - 3. 他ユーザーの投稿ページへ

- ドロップダウンメニュー表示させないように修正
 close #190 

