### PR TITLE
[Fix test#193] usersリソース関係のテスト追加、修正

### DIFF
--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -13,6 +13,12 @@ RSpec.describe User do
       expect(user.errors[:name]).to include('を入力してください')
     end
 
+    it '名前が31字以上では無効であること' do
+      user = build(:user, name: "#{'a'*31}")
+      user.valid?
+      expect(user.errors[:name]).to include('は30文字以内で入力してください')
+    end
+
     it 'メールアドレスがなければ無効な状態であること' do
       user = build(:user, email: '')
       user.valid?

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -14,7 +14,7 @@ RSpec.describe User do
     end
 
     it '名前が31字以上では無効であること' do
-      user = build(:user, name: "#{'a'*31}")
+      user = build(:user, name: ('a' * 31).to_s)
       user.valid?
       expect(user.errors[:name]).to include('は30文字以内で入力してください')
     end

--- a/spec/system/profiles_spec.rb
+++ b/spec/system/profiles_spec.rb
@@ -29,7 +29,7 @@ RSpec.describe 'Profiles', js: true do
     expect(page).to have_current_path root_path, ignore_query: true
   end
 
-  it 'プロフィールにアバター画像を設定できること' do
+  it 'プロフィールにアバター画像(.png)を設定できること' do
     login_as(user)
     visit edit_profile_path
     fill_in '身長(必須)', with: user.height
@@ -42,6 +42,21 @@ RSpec.describe 'Profiles', js: true do
     expect(page).to have_content 'プロフィールを更新しました'
     expect(page).to have_selector("img[src$='sample_man.png']")
     expect(page).to have_current_path profile_path, ignore_query: true
+  end
+
+  it 'アバター画像にpng,jpeg,jpg以外の拡張子ファイルを設定できないこと' do
+    login_as(user)
+    visit edit_profile_path
+    # fill_in '身長(必須)', with: user.height
+    # fill_in '体重(必須)', with: user.body_weight
+    # fill_in '年齢(必須)', with: user.age
+    # select '男性', from: '生まれた時の性別(必須)'
+    # select 'レベル1', from: '活動量(必須)'
+    attach_file 'user[avatar]', Rails.root.join('spec/fixtures/error.txt')
+    click_button '更新する'
+    expect(page).to have_content '更新できませんでした'
+    expect(page).to have_content 'は対応できないファイル形式です'
+    expect(page).to have_current_path edit_profile_path, ignore_query: true
   end
 
   it '未ログインではプロフィールの編集ができないこと' do

--- a/spec/system/profiles_spec.rb
+++ b/spec/system/profiles_spec.rb
@@ -32,11 +32,6 @@ RSpec.describe 'Profiles', js: true do
   it 'プロフィールにアバター画像(.png)を設定できること' do
     login_as(user)
     visit edit_profile_path
-    fill_in '身長(必須)', with: user.height
-    fill_in '体重(必須)', with: user.body_weight
-    fill_in '年齢(必須)', with: user.age
-    select '男性', from: '生まれた時の性別(必須)'
-    select 'レベル1', from: '活動量(必須)'
     attach_file 'user[avatar]', Rails.root.join('spec/fixtures/images/sample_man.png')
     click_button '更新する'
     expect(page).to have_content 'プロフィールを更新しました'
@@ -47,11 +42,6 @@ RSpec.describe 'Profiles', js: true do
   it 'アバター画像にpng,jpeg,jpg以外の拡張子ファイルを設定できないこと' do
     login_as(user)
     visit edit_profile_path
-    # fill_in '身長(必須)', with: user.height
-    # fill_in '体重(必須)', with: user.body_weight
-    # fill_in '年齢(必須)', with: user.age
-    # select '男性', from: '生まれた時の性別(必須)'
-    # select 'レベル1', from: '活動量(必須)'
     attach_file 'user[avatar]', Rails.root.join('spec/fixtures/error.txt')
     click_button '更新する'
     expect(page).to have_content '更新できませんでした'


### PR DESCRIPTION
## 概要
- バリデーション関係のテスト追加
 -  名前が31文字以上ではエラー
 - プロフィール写真(アバター画像)にpng,jpeg,jpg以外の拡張子ファイルを設定できないこと
- その他テストコードリファクタリング

## 確認方法
テストを実行して確認

## 影響範囲
テストファイルのみ

## チェックリスト
- [x] Lint のチェックをパスした
- [x] テストをパスした

## コメント
- たまにログイン処理がうまくいかない（２回目走らせるとうまくいく）ので原因を追跡調査
close #193