### PR TITLE
[hotfix#204] マイページの日付絞り込み機能のバグ修正

### DIFF
--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -44,13 +44,10 @@ class UsersController < ApplicationController
 
     set_calendar_info
 
-    @input_date = params[:date_search].to_date
-    if @input_date
-      @workouts = Workout.where(workout_date: @input_date.beginning_of_day...@input_date.end_of_day, user_id:)
-      @meals = Meal.where(meal_date: @input_date.beginning_of_day...@input_date.end_of_day, user_id:)
-      @total_calorie = MealDetail.where(meal_id: @meals.pluck(:id)).pluck(:meal_calorie).sum
-    end
-
+    @input_date = params[:date_search].to_date || Time.current.to_date
+    @workouts = Workout.where(workout_date: @input_date.beginning_of_day...@input_date.end_of_day, user_id:)
+    @meals = Meal.where(meal_date: @input_date.beginning_of_day...@input_date.end_of_day, user_id:)
+    @total_calorie = MealDetail.where(meal_id: @meals.pluck(:id)).pluck(:meal_calorie).sum
     render :show
   end
 


### PR DESCRIPTION
## 概要
- `params[:date_search].to_date`が`nil`の場合に`Time.current.to_date`を`@input_date`に代入するように修正

## 確認方法
ブラウザ上にて確認

## 影響範囲
users#showのビューおよびusersコントローラー

## チェックリスト
- [x] Lint のチェックをパスした
- [x] テストをパスした

## コメント
- date_serchメソッドが冗長であるので、モデルに寄せられるコードはリファクタリングがいいかも
close #204
