### PR TITLE
[Hotfix#230]筋トレカレンダーのバグ修正

### DIFF
--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -56,7 +56,8 @@ class UsersController < ApplicationController
   end
 
   def set_calendar_info
-    start_date = params.fetch(:start_date, Time.current).to_datetime
-    @workouts_per_month = @user.workouts.where(workout_date: start_date.in_time_zone('Tokyo').all_month)
+    start_date = Time.zone.parse(params.fetch(:start_date, Time.current)) #ActiveSupport::TimeWithZoneクラスのインスタンス
+    @workouts_per_month = @user.workouts.where(workout_date: start_date.all_month)
+    debugger
   end
 end

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -58,6 +58,5 @@ class UsersController < ApplicationController
   def set_calendar_info
     start_date = Time.zone.parse(params.fetch(:start_date, Time.current)) #ActiveSupport::TimeWithZoneクラスのインスタンス
     @workouts_per_month = @user.workouts.where(workout_date: start_date.all_month)
-    debugger
   end
 end

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -56,7 +56,7 @@ class UsersController < ApplicationController
   end
 
   def set_calendar_info
-    start_date = Time.zone.parse(params.fetch(:start_date, Time.current)) #ActiveSupport::TimeWithZoneクラスのインスタンス
+    start_date = Time.zone.parse(params.fetch(:start_date, Time.current)) # ActiveSupport::TimeWithZoneクラスのインスタンス
     @workouts_per_month = @user.workouts.where(workout_date: start_date.all_month)
   end
 end

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -57,6 +57,6 @@ class UsersController < ApplicationController
 
   def set_calendar_info
     start_date = params.fetch(:start_date, Time.current).to_datetime
-    @workouts_per_month = @user.workouts.where(workout_date: start_date.in_time_zone("Tokyo").all_month)
+    @workouts_per_month = @user.workouts.where(workout_date: start_date.in_time_zone('Tokyo').all_month)
   end
 end

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -56,7 +56,7 @@ class UsersController < ApplicationController
   end
 
   def set_calendar_info
-    start_date = Time.zone.parse(params.fetch(:start_date, Time.current)) # ActiveSupport::TimeWithZoneクラスのインスタンス
+    start_date = params.fetch(:start_date, Time.current).in_time_zone # ActiveSupport::TimeWithZoneクラスのインスタンス
     @workouts_per_month = @user.workouts.where(workout_date: start_date.all_month)
   end
 end

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -41,9 +41,7 @@ class UsersController < ApplicationController
   def date_search
     user_id = params[:user_id]
     @user = User.find(user_id)
-
     set_calendar_info
-
     @input_date = params[:date_search].to_date || Time.current.to_date
     @workouts = Workout.where(workout_date: @input_date.beginning_of_day...@input_date.end_of_day, user_id:)
     @meals = Meal.where(meal_date: @input_date.beginning_of_day...@input_date.end_of_day, user_id:)
@@ -58,7 +56,7 @@ class UsersController < ApplicationController
   end
 
   def set_calendar_info
-    start_date = Time.current
-    @workouts_per_month = @user.workouts.where(workout_date: start_date.all_month)
+    start_date = params.fetch(:start_date, Time.current).to_datetime
+    @workouts_per_month = @user.workouts.where(workout_date: start_date.in_time_zone("Tokyo").all_month)
   end
 end

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -84,7 +84,7 @@
         <% end %>
         <div class="font-bold text-lg my-4 text-center">
           <% if @workouts_per_month.present? %>
-            <p>筋トレ回数 <%= @workouts_per_month.pluck(:workout_date).uniq.size %>回/月</p>
+            <p>筋トレ回数 <%= @workouts_per_month.pluck(:workout_date).map(&:to_date).uniq.size %>回/月</p>
           <% else %>
             <p>筋トレ回数 0回/月</p>
           <% end %>


### PR DESCRIPTION
## 概要
- 筋トレカレンダーに「💪」が生えないバグを修正

## 確認方法
- ブラウザ上で確認

## 影響範囲
usersコントローラーのshowアクション、date_searchアクション

## チェックリスト
- [x] Lint のチェックをパスした
- [x] テストをパスした

## コメント
- `start_date`を取得するときに`in_time_zone`メソッドを使い`ActiveSupport::TimeWithZone`クラスのインスタンスへ変換
- ActiveRecordのメソッドが汚い部分があるので、リファクタリングを検討
close #230 
