### PR TITLE
[fix_destroy_action#232] destroyアクションのコード修正

### DIFF
--- a/app/controllers/meal_likes_controller.rb
+++ b/app/controllers/meal_likes_controller.rb
@@ -17,7 +17,7 @@ class MealLikesController < ApplicationController
     @meal = current_user.meal_likes.find(params[:id]).meal
     current_user.unlike_meal(@meal)
     respond_to do |format|
-      format.html { redirect_to request.referer }
+      format.html { redirect_to request.referer, status: :see_other }
       format.turbo_stream
     end
   end

--- a/app/controllers/workout_likes_controller.rb
+++ b/app/controllers/workout_likes_controller.rb
@@ -17,7 +17,7 @@ class WorkoutLikesController < ApplicationController
     @workout = current_user.workout_likes.find(params[:id]).workout
     current_user.unlike_workout(@workout)
     respond_to do |format|
-      format.html { redirect_to request.referer }
+      format.html { redirect_to request.referer, status: :see_other }
       format.turbo_stream
     end
   end


### PR DESCRIPTION
## 概要
- 現状バグは起きていないものの、destroyアクションに`status: :see_other`をつけていない場合にリダイレクトした時に不具合が出る可能性があるため、念のため修正
- おそらく現状はTurbo Streamの方が効いているので大丈夫であると思われる

## 確認方法
テストおよびブラウザにてdestroyアクションが動作することを確認

## 影響範囲
workout_likesコントローラー、meal_likesコントローラー（筋トレ投稿のいいね、食事投稿のいいね）

## チェックリスト
- [x] Lint のチェックをパスした
- [x] テストをパスした

## コメント
- status: :see_otherの挙動について確認しておく
close #232 
